### PR TITLE
fix(kds): wait for store state to match golden files instead of sleeping

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -85,16 +85,15 @@ var _ = Describe("Full sync tests", func() {
 			}()
 		}
 
-		// Wait for some time to ensure sync was complete
-		time.Sleep(time.Second * 5)
+		// Wait for sync to complete by polling until all stores match golden files
+		Eventually(func(g Gomega) {
+			for zoneName, zoneStore := range zones {
+				out, err := test_store.ExtractResources(ctx, zoneStore)
+				g.Expect(err).To(Succeed())
+				g.Expect(out).To(matchers.MatchGoldenEqual(folder, zoneName+".golden.yaml"), "zone %s", zoneName)
+			}
+		}, "30s", "100ms").Should(Succeed())
 		close(done)
 		wg.Wait()
-
-		// Compare golden files
-		for zoneName, zoneStore := range zones {
-			out, err := test_store.ExtractResources(ctx, zoneStore)
-			Expect(err).To(Succeed())
-			Expect(out).To(matchers.MatchGoldenEqual(folder, zoneName+".golden.yaml"), "zone %s", zoneName)
-		}
 	}, test.EntriesAsFolder("full_sync"))
 })


### PR DESCRIPTION
## Summary

- Replace `time.Sleep(5s)` with `Eventually` that polls all zone stores until they match golden files while CPs are still running
- The previous fix (PR #25) waited only for `ZoneInsight` to appear, which was insufficient — other resources (Zone, MeshService, MeshTimeout, etc.) could still be in-flight when the comparison ran
- With `Eventually("30s", "100ms")`, the test retries the golden file comparison until all stores reach the expected state, then shuts down the CPs

## Root cause

The original `time.Sleep(5s)` was flaky because sync timing is non-deterministic. The `ZoneInsight`-based fix in PR #25 was still insufficient: `ZoneInsight` appearing in the global store only signals that a zone connected, not that all its resources finished syncing.

## Test plan

- [ ] `make test TEST_PKG_LIST=./pkg/kds/context/...` passes consistently
- [ ] CI with `ci/verify-stability` label shows no regressions

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)