### PR TITLE
fix(test): retry PodNameOfApp in keepConnectionOpen to avoid race after KillAppPod

### DIFF
--- a/test/e2e_env/kubernetes/gateway/resources.go
+++ b/test/e2e_env/kubernetes/gateway/resources.go
@@ -120,8 +120,15 @@ spec:
 		// Open TCP connections to the gateway
 		defer GinkgoRecover()
 
-		demoClientPod, err := PodNameOfApp(kubernetes.Cluster, "demo-client", waitingClientNamespace)
-		Expect(err).ToNot(HaveOccurred())
+		// After KillAppPod the old pod may still be Terminating while the new one
+		// is starting, causing PodNameOfApp to see 2 pods and return an error.
+		// Retry until exactly one pod is present.
+		var demoClientPod string
+		Eventually(func(g Gomega) {
+			var err error
+			demoClientPod, err = PodNameOfApp(kubernetes.Cluster, "demo-client", waitingClientNamespace)
+			g.Expect(err).ToNot(HaveOccurred())
+		}, "30s", "1s").Should(Succeed())
 
 		cmd := []string{"telnet", gatewayHost, "8080"}
 		// We pass in a stdin that blocks so that telnet will keep the


### PR DESCRIPTION
## Summary

Fixes flaky test `kubernetes/gateway/resources It` (#17).

- After `KillAppPod` the old pod stays in **Terminating** state while the new pod starts, creating a brief window where `PodNameOfApp` sees 2 pods and returns an error ("expected 1 pods, got 2").
- The `keepConnectionOpen` goroutine recovered silently via `defer GinkgoRecover()` and exited without establishing a TCP connection.
- With no open connection, the gateway's connection limit (1) was never saturated, so all curl requests returned exit code 0 instead of 52/56.
- `Eventually` timed out after 60s with the assertion never satisfied.

**Fix:** wrap the `PodNameOfApp` call in an `Eventually` (30s / 1s) so it retries until exactly one pod exists before running `telnet`.

## Test plan

- [ ] Verify CI passes on the `sidecarContainers` kubernetes e2e job
- [ ] Add label `ci/verify-stability` to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)