### PR TITLE
fix(e2e): wait for spire-controller-manager before proceeding in Deploy

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -72,6 +72,10 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
+	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds a readiness check for `spire-controller-manager` at the end of the `Deploy` method in `test/framework/deployments/spire/kubernetes.go`
- Fixes the race condition causing `kubernetes/meshidentity/spire BeforeAll` to fail intermittently

**Root cause:** `Deploy` returned after waiting for agent/server/spiffe-csi-driver/spiffe-oidc-discovery-provider but not `spire-controller-manager`. The controller manager hosts the `vclusterspiffeid.kb.io` admission webhook. When `BeforeAll` applied a `ClusterSPIFFEID` immediately after `Deploy` returned, the webhook endpoints were not yet available, causing admission failures.

**Fix:** Added `t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` using the same `isPodReady` helper with the existing `DefaultRetries*3` timeout, matching the pattern for the other SPIRE components.

Fixes #31

> Changelog: skip

## Test plan

- [ ] CI passes with `ci/verify-stability` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)