### PR TITLE
fix(kds): wait for global gRPC server before starting zone CPs in test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -2,6 +2,7 @@ package context_test
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"strings"
@@ -64,6 +65,17 @@ var _ = Describe("Full sync tests", func() {
 			defer GinkgoRecover()
 			Expect(rt.Start(done)).To(Succeed())
 		}()
+		// Wait for the global CP's gRPC server to be ready before connecting zone CPs.
+		// Without this, zone CPs may get "connection refused" on their first dial attempt,
+		// which terminates the KDS mux client with no retry, preventing zone sync.
+		Eventually(func() error {
+			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", globalPort))
+			if err != nil {
+				return err
+			}
+			_ = conn.Close()
+			return nil
+		}, "10s", "100ms").Should(Succeed())
 		// start zones
 		for zoneName, zoneStore := range zones {
 			if zoneName == "global" {


### PR DESCRIPTION
## Summary

Fixes flaky test: `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled`
File: `pkg/kds/context/full_sync_test.go`
Closes #33

## Root Cause

Zone CPs were started immediately after spawning the global CP goroutine, before the gRPC server had called `net.Listen`. Zone mux clients would hit "connection refused" on their first dial attempt, triggering the `ResilientComponentBaseBackoff` (5-second base delay). This consumed a large portion of the 30-second `Eventually` window for zone sync verification, causing the test to time out.

## What Changed

Added an `Eventually` block (10s timeout, 100ms polling) between starting the global CP goroutine and starting zone CPs:

```go
Eventually(func() error {
    conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", globalPort))
    if err != nil {
        return err
    }
    _ = conn.Close()
    return nil
}, "10s", "100ms").Should(Succeed())
```

## Why the Fix Is Stable

Zone CPs only start after the global CP's TCP listener is confirmed accepting connections, eliminating the startup race. The first dial from each zone CP succeeds immediately, so no backoff occurs. The full 30-second window remains available for actual KDS synchronization. The 10-second wait budget is generous — the server typically starts in milliseconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)