### PR TITLE
fix(kds): wait for global CP to listen before starting zone CPs in test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -2,6 +2,7 @@ package context_test
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"strings"
@@ -64,6 +65,19 @@ var _ = Describe("Full sync tests", func() {
 			defer GinkgoRecover()
 			Expect(rt.Start(done)).To(Succeed())
 		}()
+		// Wait for the global CP's gRPC server to start accepting connections
+		// before starting zone CPs. Without this, zone mux clients can hit
+		// "connection refused" on their first dial, triggering a 5-second
+		// resilient-component backoff that can exhaust the 30-second Eventually
+		// window for store sync verification.
+		Eventually(func() error {
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", globalPort), time.Second)
+			if err != nil {
+				return err
+			}
+			_ = conn.Close()
+			return nil
+		}, "10s", "100ms").Should(Succeed())
 		// start zones
 		for zoneName, zoneStore := range zones {
 			if zoneName == "global" {


### PR DESCRIPTION
## Summary

- Adds TCP readiness check before starting zone CPs in `full_sync_test.go`
- Zone CPs now only start after the global CP's gRPC server is confirmed listening
- Fixes the intermittent `testdata/full_sync/policy-with-kds-disabled` failure

## Root Cause

The test started zone CPs immediately after spawning the global CP goroutine, before `net.Listen` was called on the gRPC port. Zone mux clients attempted to dial `localhost:<globalPort>` and hit `connection refused`. This triggered `ResilientComponentBaseBackoff` (5-second base delay), consuming a large portion of the 30-second `Eventually` window for store sync verification. On slower CI runs, zone-1's Zone and ZoneInsight resources never appeared in the global store before the timeout, causing intermittent failures.

## What Changed

In `pkg/kds/context/full_sync_test.go`: added an `Eventually` block (10s timeout, 100ms polling) between starting the global CP goroutine and starting zone CPs:

```go
Eventually(func() error {
    conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", globalPort), time.Second)
    if err != nil {
        return err
    }
    _ = conn.Close()
    return nil
}, "10s", "100ms").Should(Succeed())
```

## Why the Fix Is Stable

Zone CPs only start after the global CP's TCP listener is confirmed accepting connections, eliminating the startup race. The first dial from each zone CP will always succeed, so `ResilientComponentBaseBackoff` is never triggered. The full 30-second `Eventually` window is now available for actual KDS sync work. The 10s readiness timeout is generous — the server typically binds in milliseconds.

Fixes #33

## Test plan

- [ ] Run `make test TEST_PKG_LIST=./pkg/kds/context/...` to verify the test passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)