### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase timeout in spire TLS check

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "60s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Summary

Fixes flaky test `kubernetes/meshidentity/spire It` (issue #32).

- Changed `Expect(err)` → `g.Expect(err)` inside the `Eventually(func(g Gomega))` block
- Changed `Expect(s)` → `g.Expect(s)` inside the `Eventually(func(g Gomega))` block
- Increased timeout from `"5s"` to `"60s"` for TLS handshake stat check

## Root Cause

The `Eventually` block at line 131 (checking `listener.*_80.ssl.handshake` stats) had two problems:

1. **Wrong Gomega usage**: Inner assertions used `Expect(...)` instead of `g.Expect(...)`. When `Eventually` receives a `func(g Gomega)` argument, all assertions inside must use the `g` Gomega instance. Using the outer `Expect` causes a fatal test failure on the very first failed attempt — no retry, defeating the purpose of `Eventually`.

2. **Insufficient timeout**: The TLS handshake stat is only updated after SPIRE issues an SVID, kuma-cp pushes updated xDS config, and Envoy completes a TLS handshake. Under CI load, this SVID provisioning → xDS push → sidecar refresh chain can take 30–45s, making 5s far too short.

## Why the Fix Is Stable

- `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern — it captures assertion failures and lets `Eventually` retry rather than failing immediately.
- 60s gives ample time for the full SPIRE SVID provisioning → kuma-cp xDS push → sidecar certificate refresh chain to complete even under CI load.
- The first `Eventually` block in the same test already uses 30s for traffic readiness; the TLS stat check needs at least as long since it depends on the same chain completing.

Closes #32

> Changelog: skip