### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase timeout in spire TLS check

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Summary

Fixes flaky test `kubernetes/meshidentity/spire It` (issue #32).

- Replace `Expect(err)` and `Expect(s)` with `g.Expect(err)` and `g.Expect(s)` inside `Eventually(func(g Gomega))` block
- Increase timeout from `"5s"` to `"30s"` for the TLS handshake stat check

## Root cause

The `Eventually(func(g Gomega))` block at line 131 used the outer `Expect` instead of the scoped `g.Expect`. Per Gomega docs, all assertions inside `Eventually(func(g Gomega))` must use the `g` instance — using the outer `Expect` causes an immediate fatal failure on the first failed attempt with no retry, defeating the purpose of `Eventually`.

Additionally, the 5s timeout was too short for SPIRE to issue SVIDs and for Envoy to complete the first TLS handshake under CI load.

## Why the fix is stable

Using `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern — it allows `Eventually` to capture assertion failures and retry rather than panicking immediately. The 30s timeout matches the first `Eventually` block in the same test (which already handles Spire propagation delay) and gives ample headroom for the SPIRE SVID → xDS push → sidecar refresh chain.

Closes #32