### PR TITLE
fix(kds): use 127.0.0.1 instead of localhost in full sync test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Full sync tests", func() {
 		// refused" on their first dial and trigger the resilient component's base
 		// backoff (5s), consuming most of the 30s Eventually window for sync verification.
 		Eventually(func() error {
-			conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", globalPort), time.Second)
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", globalPort), time.Second)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ var _ = Describe("Full sync tests", func() {
 			cfg.Store.Type = config_store.MemoryStore
 			cfg.Mode = config_core.Zone
 			cfg.Multizone.Zone.Name = zoneName
-			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://localhost:%d", globalPort)
+			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
 			cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 			rt := setup.NewTestRuntime(ctx, cfg, zoneStore)
 			Expect(zone.Setup(rt)).To(Succeed())


### PR DESCRIPTION
## Summary

- Replace `localhost` with `127.0.0.1` in `full_sync_test.go` for both the TCP readiness check and the zone `GlobalAddress`

Fixes #33

## Root Cause

The previous fix added an `Eventually` block to wait for the global CP's gRPC port before starting zone CPs. However, it used `localhost` in both the readiness check and `GlobalAddress`. On Linux runners, `localhost` can resolve to `[::1]` (IPv6) while the gRPC server binds to `0.0.0.0` (IPv4 only).

This created a subtle race: the port-readiness check via `127.0.0.1` would succeed, but the zone mux client's gRPC dial to `[::1]` would still hit `connection refused` — triggering `ResilientComponentBaseBackoff` (5-second base delay) and consuming the 30-second `Eventually` window for sync verification.

## What Changed

Replaced `localhost` with `127.0.0.1` in two places:

```go
// Port readiness check
conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", globalPort), time.Second)

// Zone GlobalAddress
cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
```

## Why the Fix Is Stable

Both the readiness check and zone CP connections now use the same IPv4 loopback interface that the gRPC server binds to. There is no IPv6 resolution step that could produce `[::1]` and trigger `connection refused`. Zone CPs always connect successfully on the first attempt — no backoff is triggered, and the full 30-second sync window is available for actual KDS synchronization work.

## Test plan

- [ ] Run `make test TEST_PKG_LIST=./pkg/kds/context/...` to verify the test passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)