### PR TITLE
fix(e2e): fix flaky spire test with g.Expect and increased timeouts

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "60s", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "60s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #32 — `kubernetes/meshidentity/spire It should receive identity from Spire and traffic works`

### Root Cause

Two compounding issues caused the flake:

1. **Wrong Gomega usage (lines 133–134):** The `Eventually(func(g Gomega))` block used `Expect(err)` and `Expect(s)` instead of `g.Expect(err)` and `g.Expect(s)`. When `Eventually` receives a `func(g Gomega)` argument, all assertions must use the `g` instance. Using the outer `Expect` causes an immediate fatal failure on the first attempt — no retry occurs, defeating the purpose of `Eventually`.

2. **Insufficient timeouts:** Both `Eventually` blocks had short timeouts that were inadequate for the full Spire SVID provisioning → kuma-cp xDS push → sidecar certificate refresh chain, which can take 30–45s under CI load.

### What Changed

- `Expect(err)` → `g.Expect(err)` inside `Eventually(func(g Gomega))`
- `Expect(s)` → `g.Expect(s)` inside `Eventually(func(g Gomega))`
- Traffic check timeout: `"30s"` → `"60s"`
- TLS stats check timeout: `"5s"` → `"60s"`

### Why the Fix Is Stable

Using `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern — it allows `Eventually` to capture assertion failures and retry rather than panicking. The 60s timeouts account for Spire SVID issuance, kuma-cp xDS push, and Envoy sidecar certificate refresh under CI load.

## Test plan

- [ ] CI passes with `ci/verify-stability` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)