### PR TITLE
fix(e2e): wait for spire-controller-manager-webhook endpoints before applying ClusterSPIFFEID

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -1,8 +1,11 @@
 package spire
 
 import (
+	"context"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -72,7 +75,30 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
+	// Wait for the spire-controller-manager webhook service to have endpoints before returning.
+	// The controller-manager may run as a sidecar in spire-server-0 or as a separate deployment
+	// depending on the chart version, so we wait for the service endpoints directly rather than
+	// waiting for a pod with a specific label.
+	_, err = retry.DoWithRetryE(cluster.GetTesting(),
+		"wait for spire-controller-manager-webhook to have endpoints",
+		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultTimeout,
+		func() (string, error) {
+			client, err := k8s.GetKubernetesClientFromOptionsE(cluster.GetTesting(), cluster.GetKubectlOptions(t.namespace))
+			if err != nil {
+				return "", err
+			}
+			endpoints, err := client.CoreV1().Endpoints(t.namespace).Get(context.Background(), "spire-controller-manager-webhook", metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			for _, subset := range endpoints.Subsets {
+				if len(subset.Addresses) > 0 {
+					return "", nil
+				}
+			}
+			return "", errors.Errorf("service %q has no ready endpoints yet", "spire-controller-manager-webhook")
+		})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Replaces the incorrect pod-label wait from PR #35 with a direct check of the `spire-controller-manager-webhook` Endpoints resource
- Waits until the service has at least one ready address before `Deploy` returns, ensuring the webhook is available for `ClusterSPIFFEID` admission requests

Fixes #31

> Changelog: skip

## Root Cause

The previous fix (PR #35) tried to wait for a pod with label `app.kubernetes.io/name=spire-controller-manager`. However, CI logs confirmed that no such standalone pod exists in the `spire-system` namespace — the controller-manager runs as a **sidecar container inside `spire-server-0`**. This caused the pod-label wait to time out after 4.5 minutes with:

```
'Wait for num pods created to match desired count 1.' unsuccessful after 90 retries
```

The original failure was:
```
Internal error occurred: failed calling webhook "vclusterspiffeid.kb.io":
no endpoints available for service "spire-controller-manager-webhook"
```

`YamlK8s(workflowRegistration)` was called with 30 retries (90s total), but the `spire-controller-manager-webhook` service had zero endpoints throughout that window because the controller-manager sidecar hadn't registered yet — even though `spire-server-0` was already marked as ready by `WaitUntilPodAvailableE`.

## What Changed

Replaced the incorrect `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` with a `retry.DoWithRetryE` loop that queries the Kubernetes Endpoints API directly:

```go
_, err = retry.DoWithRetryE(cluster.GetTesting(),
    "wait for spire-controller-manager-webhook to have endpoints",
    framework.DefaultRetries*3,
    framework.DefaultTimeout,
    func() (string, error) {
        client, _ := k8s.GetKubernetesClientFromOptionsE(...)
        endpoints, _ := client.CoreV1().Endpoints(t.namespace).Get(ctx, "spire-controller-manager-webhook", ...)
        for _, subset := range endpoints.Subsets {
            if len(subset.Addresses) > 0 {
                return "", nil
            }
        }
        return "", errors.Errorf("service has no ready endpoints yet")
    })
```

## Why This Fix Is Stable

1. **Chart-version-agnostic**: Checks the service endpoints directly rather than relying on pod labels, which vary by chart version (sidecar vs. separate deployment).
2. **Directly checks the precondition**: The original failure was "no endpoints available". We now wait until endpoints ARE available before returning from `Deploy`.
3. **Same generous timeout**: Uses `DefaultRetries*3` (90 retries × 3s = 4.5 min), matching the timeout used for other SPIRE components.
4. **No false positives**: An Endpoints address entry means kube-proxy has registered the pod IP — the webhook can actually accept connections.

## Test plan

- [ ] CI passes with `ci/verify-stability` label

🤖 Generated with [Claude Code](https://claude.ai/claude-code)