### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase timeout in spire test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Summary

Fixes flaky test `kubernetes/meshidentity/spire It` (issue #32). Revises the approach from PR #36 which failed CI due to a missing dependency that is now on master.

- Changed `Expect(err)` → `g.Expect(err)` inside `Eventually(func(g Gomega))` block
- Changed `Expect(s)` → `g.Expect(s)` inside `Eventually(func(g Gomega))` block
- Increased TLS handshake stat check timeout from `"5s"` to `"30s"`

## Root Cause

Two problems in the second `Eventually` block (lines 131-135 of `spire.go`):

1. **Wrong Gomega usage**: Inner assertions used `Expect(...)` instead of `g.Expect(...)`. When `Eventually` receives a `func(g Gomega)` argument, all assertions inside **must** use the `g` Gomega instance. Using the outer `Expect` causes an immediate fatal failure on the first attempt (no retry), bypassing Eventually's retry logic entirely and potentially panicking inside the goroutine.

2. **Insufficient timeout**: The `listener.*_80.ssl.handshake` stat is only incremented after Spire has issued an SVID certificate and Envoy has completed a full mTLS handshake. With SPIFFE identity propagation involved, 5s is consistently too short.

## Why PR #36 Failed

PR #36 was cut from an older master that didn't include `c116dbd12` (`fix(e2e): wait for spire-controller-manager before applying ClusterSPIFFEID`). Without that fix, the `BeforeAll` setup timed out waiting for the `spire-controller-manager` pod that handles `ClusterSPIFFEID` admission — causing a failure unrelated to PR #36's changes. This PR is based on current master which already includes `c116dbd12`.

## Why the Fix Is Stable

Using `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern: it captures assertion failures and lets `Eventually` retry on the next tick. The 30s timeout matches the first `Eventually` block in the same test (line 122), which already accounts for Spire certificate propagation delay.

Closes #32

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)