### PR TITLE
fix(e2e): retry ClusterSPIFFEID apply and fix g.Expect in spire test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -53,9 +53,14 @@ spec:
 				// default spire helm uses 1.27.16 which fails since there is no image
 				spire.WithKubectlVersion("v1.31.11"),
 			)).
-			Install(YamlK8s(workflowRegistration)).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
+
+		// Apply ClusterSPIFFEID with retry: the spire-controller-manager admission
+		// webhook may not be ready immediately after the SPIRE pods become available.
+		Eventually(func(g Gomega) {
+			g.Expect(YamlK8s(workflowRegistration)(kubernetes.Cluster)).To(Succeed())
+		}, "30s", "2s").Should(Succeed())
 	})
 
 	AfterEachFailure(func() {
@@ -130,8 +135,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -72,10 +72,6 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
-	if err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Revised fix for flaky test `kubernetes/meshidentity/spire It` (issue #32).

- Fix `Expect(err)` → `g.Expect(err)` and `Expect(s)` → `g.Expect(s)` inside `Eventually(func(g Gomega))` block
- Increase TLS handshake stat timeout from `5s` to `30s`
- Apply `ClusterSPIFFEID` outside `NewClusterSetup()` with `Eventually` retry
- Remove the `spire-controller-manager` pod-creation wait from `kubernetes.go`

## Root Cause

Two issues were causing flakes:

**1. Wrong Gomega usage in TLS check (original issue #32)**

The second `Eventually` block used bare `Expect(err)` / `Expect(s)` instead of `g.Expect(...)`. When `Eventually` receives `func(g Gomega)`, all inner assertions must use `g` — otherwise the first failure is a fatal panic with no retry. The 5s timeout was also too short for Spire certificate propagation and the first TLS handshake.

**2. Fragile `spire-controller-manager` pod-creation wait (PR #36 CI failure)**

`c116dbd12` added a `WaitUntilNumPodsCreatedE` call for `app.kubernetes.io/name=spire-controller-manager` in `kubernetes.go`. The helm chart is installed without pinning a version, so pod labels can differ across releases. When the label doesn't match, the wait exhausts all 90 retries (270s) and the `BeforeAll` fails — even though SPIRE itself is healthy. This caused PR #36's CI to fail at `spire.go:58`.

## What Changed

**`test/e2e_env/kubernetes/meshidentity/spire.go`:**
- Moved `YamlK8s(workflowRegistration)` out of `NewClusterSetup()` into a separate `Eventually` block that retries for 30s. This directly tests webhook availability by retrying the actual operation that needs it.
- Fixed `Expect(err)` → `g.Expect(err)` and `Expect(s)` → `g.Expect(s)` in the TLS handshake check.
- Increased TLS handshake check timeout from `5s` to `30s`.

**`test/framework/deployments/spire/kubernetes.go`:**
- Removed the `spire-controller-manager` pod-creation wait (reverts the fragile part of `c116dbd12`). Webhook readiness is now handled by retrying the `ClusterSPIFFEID` apply in the test.

## Why the Fix Is Stable

- `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern — failures are captured and retried rather than causing an immediate panic.
- Retrying the `ClusterSPIFFEID` apply is more robust than waiting for a pod with a potentially-version-dependent label: it tests the exact condition needed (webhook is serving) and retries up to 30s.
- The 30s timeouts match the first `Eventually` block in the same test, which already accounts for Spire propagation delay.

Closes #32

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)