### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase timeouts in spire test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "60s", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
Fixes #32

## Root Cause

Two bugs in `test/e2e_env/kubernetes/meshidentity/spire.go`:

1. **Wrong Gomega usage in TLS stats `Eventually` (lines 131-135):** The block used bare `Expect(err)` and `Expect(s)` instead of `g.Expect(err)` and `g.Expect(s)`. When `Eventually` receives a `func(g Gomega)` argument, all assertions inside *must* use the `g` Gomega instance. Using the outer `Expect` calls `Fail()` directly, bypassing the retry mechanism — the first transient error immediately fails the test with no retry.

2. **Insufficient timeouts:** The TLS stats `Eventually` had a `"5s"` timeout — too short for Spire to issue an SVID and Envoy to complete its first TLS handshake. The traffic `Eventually` had a `"30s"` timeout with `MustPassRepeatedly(5)` — on slow CI runners, Spire certificate propagation can exceed this window.

## What Changed

In `test/e2e_env/kubernetes/meshidentity/spire.go`:
- `Expect(err)` → `g.Expect(err)` inside `Eventually(func(g Gomega))`
- `Expect(s)` → `g.Expect(s)` inside `Eventually(func(g Gomega))`
- TLS stats `Eventually` timeout increased from `"5s"` to `"30s"`
- Traffic `Eventually` timeout increased from `"30s"` to `"60s"`

## Why the Fix Is Stable

Using `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern (documented in `.github/instructions/e2e-testing.instructions.md`) — failures are captured for retry rather than immediately fatal. The 30s TLS stats timeout and 60s traffic timeout give sufficient headroom for Spire SVID issuance and Envoy TLS handshake completion on CI runners.

> Changelog: skip