### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase spire-controller-manager timeout

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -72,7 +72,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
+	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager", framework.DefaultRetries*5)
 	if err != nil {
 		return err
 	}
@@ -80,14 +80,19 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	return nil
 }
 
-func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) error {
+func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string, retries ...int) error {
+	r := framework.DefaultRetries * 3 // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+	if len(retries) > 0 {
+		r = retries[0]
+	}
+
 	err := k8s.WaitUntilNumPodsCreatedE(cluster.GetTesting(),
 		cluster.GetKubectlOptions(t.namespace),
 		metav1.ListOptions{
 			LabelSelector: selector,
 		},
 		1,
-		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		r,
 		framework.DefaultTimeout)
 	if err != nil {
 		return err
@@ -107,7 +112,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 		if err := k8s.WaitUntilPodAvailableE(cluster.GetTesting(),
 			cluster.GetKubectlOptions(t.namespace),
 			pod.Name,
-			framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+			r,
 			framework.DefaultTimeout); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes the flaky `kubernetes/meshidentity/spire It` test (issue #32). Two separate issues were causing failures:

1. **Wrong Gomega usage in `spire.go`**: The TLS handshake `Eventually` block used `Expect(err)` / `Expect(s)` instead of `g.Expect(err)` / `g.Expect(s)`. When `Eventually` receives a `func(g Gomega)` argument, all assertions must use the `g` instance — using the outer `Expect` causes an immediate fatal failure on the first attempt with no retry. Also increased the timeout from `5s` to `30s` since the `ssl.handshake` stat only increments after Spire issues a certificate and Envoy completes a TLS handshake.

2. **Insufficient retry budget for `spire-controller-manager` in `kubernetes.go`**: PR #36 CI failed because the `spire-controller-manager` pod was never created within `DefaultRetries*3 = 270s`. This component starts last (after agent, server, csi-driver, and oidc-provider) and may stall on image pulls in slow CI environments. Increased its specific budget to `DefaultRetries*5 = 450s` via a variadic `retries` parameter on `isPodReady`.

## Root cause

- `Expect` inside `Eventually(func(g Gomega))` → no retry on failure
- 5s too short for first TLS handshake after SPIFFE identity propagation
- `spire-controller-manager` pod creation exceeding 270s budget in CI (image pull delay)

## What changed

- `test/e2e_env/kubernetes/meshidentity/spire.go`: `Expect` → `g.Expect`, timeout `5s` → `30s`
- `test/framework/deployments/spire/kubernetes.go`: `isPodReady` accepts variadic `retries` param; `spire-controller-manager` gets `DefaultRetries*5` instead of `DefaultRetries*3`

## Why the fix is stable

`g.Expect` inside `Eventually(func(g Gomega))` is the required pattern per Gomega docs and project guidelines — it lets `Eventually` retry on failure. The 30s timeout matches the first `Eventually` block which already handles Spire propagation delay. The 450s budget for `spire-controller-manager` gives sufficient headroom even on slow CI runners while keeping the default 270s for other components that start earlier.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)