### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase timeout for spire TLS stats

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Summary

- Fix `g.Expect` usage inside `Eventually(func(g Gomega))` for the TLS handshake stats check
- Increase timeout from `5s` to `30s` for the same block

Fixes #32

> Changelog: skip

## Root Cause

In `test/e2e_env/kubernetes/meshidentity/spire.go`, the second `Eventually` block uses a `func(g Gomega)` signature but the inner assertions used the outer `Expect(...)` instead of `g.Expect(...)`. This means:
- On the first failed assertion, the outer `Expect` causes an immediate fatal test failure — `Eventually` never retries
- A panic can occur inside the goroutine, masking the real error

Additionally, the timeout was `5s`, too short for Spire to distribute a certificate and for Envoy to complete its first TLS handshake after SPIFFE identity propagation.

## What Changed

In `test/e2e_env/kubernetes/meshidentity/spire.go`:
- `Expect(err)` → `g.Expect(err)` inside `Eventually(func(g Gomega))`
- `Expect(s)` → `g.Expect(s)` inside `Eventually(func(g Gomega))`
- Timeout `"5s"` → `"30s"` to match the first `Eventually` block in the same test

## Why the Fix Is Stable

Using `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern: it captures failures and lets `Eventually` retry rather than panicking. The 30s timeout matches the existing timeout on the traffic check block, which already accounts for Spire propagation delay.

## Test plan

- [ ] CI passes with `ci/verify-stability` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)