### PR TITLE
fix(e2e): fix g.Expect usage and remove broken spire-controller-manager pod wait

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -72,10 +72,8 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
-	if err != nil {
-		return err
-	}
+	// spire-controller-manager runs as a sidecar in the spire-server pod in this helm chart
+	// version, so it is already covered by the server pod readiness check above.
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes the flaky `kubernetes/meshidentity/spire It` test (issue #32) by addressing two separate issues that together caused CI failures:

- Fixed `Expect(err)`/`Expect(s)` → `g.Expect(err)`/`g.Expect(s)` inside `Eventually(func(g Gomega))` in `spire.go`
- Removed the broken `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` wait from `kubernetes.go`
- Increased TLS handshake stats timeout from `"5s"` to `"30s"`

## Root Cause

**Issue 1 (original flake at line 122):** The second `Eventually` block checking TLS handshake stats used bare `Expect()` instead of `g.Expect()`. When `Eventually` receives a `func(g Gomega)` argument, all inner assertions must use the `g` Gomega instance. Using the outer `Expect` causes an immediate test failure on the first attempt (no retry), and can panic inside the goroutine. Combined with the 5s timeout being too short for Spire certificate distribution, this caused the flake.

**Issue 2 (regression from c116dbd12, causing PR #36 CI failure):** The `spire-controller-manager` pod wait added to `kubernetes.go` used the label selector `app.kubernetes.io/name=spire-controller-manager`. In this version of the SPIRE hardened helm chart, the controller-manager runs as a **sidecar container inside `spire-server-0`**, not as a separate pod. No pod with that label exists, so `WaitUntilNumPodsCreatedE` times out after 90 retries (4.5 minutes), failing `BeforeAll`. The server pod readiness check (already present) already covers the controller-manager sidecar.

## What Changed

- `test/e2e_env/kubernetes/meshidentity/spire.go`: `Expect` → `g.Expect` inside `Eventually`, timeout `"5s"` → `"30s"`
- `test/framework/deployments/spire/kubernetes.go`: Removed the unreachable `isPodReady` call for `spire-controller-manager`, replaced with an explanatory comment

## Why the Fix Is Stable

1. `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern — it lets `Eventually` retry on failure instead of panicking. The 30s timeout matches the first `Eventually` block in the same test.
2. Removing the pod wait eliminates the 4.5-minute timeout failure. The `spire-server` pod readiness check (which includes the controller-manager sidecar) already guarantees the webhook is available before `ClusterSPIFFEID` is applied.

Fixes #32