### PR TITLE
fix(kds): document IPv4 requirement to prevent regression in full sync test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -75,6 +75,9 @@ var _ = Describe("Full sync tests", func() {
 		// starting zone CPs. Without this, zone mux clients can hit "connection
 		// refused" on their first dial and trigger the resilient component's base
 		// backoff (5s), consuming most of the 30s Eventually window for sync verification.
+		// Use 127.0.0.1 explicitly (not "localhost") because on Linux "localhost" can
+		// resolve to [::1] (IPv6) while the gRPC server binds on 0.0.0.0 (IPv4 only),
+		// causing the dial to fail even after the port-readiness check passes.
 		Eventually(func() error {
 			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", globalPort), time.Second)
 			if err != nil {
@@ -92,6 +95,7 @@ var _ = Describe("Full sync tests", func() {
 			cfg.Store.Type = config_store.MemoryStore
 			cfg.Mode = config_core.Zone
 			cfg.Multizone.Zone.Name = zoneName
+			// Use 127.0.0.1 explicitly; see comment above about IPv6 resolution.
 			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
 			cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 			rt := setup.NewTestRuntime(ctx, cfg, zoneStore)


### PR DESCRIPTION
## Summary

- Add comments in `pkg/kds/context/full_sync_test.go` explaining why `127.0.0.1` must be used instead of `localhost` in both the port-readiness check and the zone `GlobalAddress`

Fixes #33

## Root Cause

The test `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled` was flaky for two related reasons:

1. **Startup race**: Zone CPs were started immediately after the global CP goroutine, before the gRPC server had called `net.Listen`. Zone mux clients hit **"connection refused"** on their first dial, triggering the resilient component's **5-second base backoff** (`ResilientComponentBaseBackoff`). During that backoff, zone resources never appeared in the global store, and the 30s `Eventually` block expired.

2. **IPv6 resolution**: `localhost` can resolve to `[::1]` (IPv6) on Linux CI runners, while the gRPC server binds only on `0.0.0.0` (IPv4). This meant even with the port-readiness check present, zone mux clients using `localhost` in `GlobalAddress` could still hit "connection refused" when dialing `[::1]`.

The CI failure showed: `dial tcp [::1]:42345: connect: connection refused` for zone-1 while zone-2 (which resolved `localhost` to `127.0.0.1`) connected successfully.

## What Changed

Previous commits already fixed the behavior:
- `88b348f`: Added `Eventually` port-readiness check before starting zone CPs
- `8b97f68`: Changed `localhost` → `127.0.0.1` in readiness check and `GlobalAddress`
- `71a801f`: Added `DeferCleanup` goroutine cleanup for test failure safety

This PR adds **comments** explaining the IPv4 (`127.0.0.1`) requirement at both usage sites, so future maintainers understand why `localhost` must not be used here and don't inadvertently reintroduce the flake.

## Why the Fix Is Stable

- Zone CPs only start after the global CP's TCP listener is confirmed accepting connections (port-readiness `Eventually`)
- Both the readiness check and the `GlobalAddress` use explicit `127.0.0.1`, bypassing DNS resolution that could return `[::1]` on Linux
- All goroutines are cleaned up via `DeferCleanup` even on test failure
- Comments prevent future regression by documenting the IPv4 constraint

## Test plan

- [ ] CI passes with `ci/verify-stability` label
- [ ] `Full sync tests` pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)