### PR TITLE
fix(e2e): fix g.Expect usage and remove broken spire-controller-manager pod wait

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -72,10 +72,10 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
-	if err != nil {
-		return err
-	}
+	// Note: spire-controller-manager runs as a sidecar inside spire-server-0, not as a
+	// separate pod, so there is no pod with label app.kubernetes.io/name=spire-controller-manager.
+	// The server pod readiness check above already guarantees the controller-manager (and its
+	// admission webhook) is available before any ClusterSPIFFEID resources are applied.
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes the flaky `kubernetes/meshidentity/spire It` test (issue #32).

- Fixed `Expect(err)`/`Expect(s)` → `g.Expect(err)`/`g.Expect(s)` inside `Eventually(func(g Gomega))` in `spire.go`; increased TLS handshake stats timeout from `"5s"` to `"30s"`
- Removed the broken `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` wait from `kubernetes.go`; replaced with an explanatory comment

## Test plan

- [ ] CI passes on kubernetes e2e suite
- [ ] `MeshIdentity Spire should receive identity from Spire and traffic works` passes

Fixes #32