### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase timeout in spire TLS check

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Summary

Fixes flaky test `kubernetes/meshidentity/spire It` (issue #32).

- Changed `Expect(err)` → `g.Expect(err)` inside the `Eventually(func(g Gomega))` block
- Changed `Expect(s)` → `g.Expect(s)` inside the `Eventually(func(g Gomega))` block
- Increased timeout from `"5s"` to `"30s"` for TLS handshake stat check

## Root Cause

The second `Eventually` block (checking `listener.*_80.ssl.handshake` stats) had two problems:

1. **Wrong Gomega usage**: Inner assertions used `Expect(...)` instead of `g.Expect(...)`. When `Eventually` receives a `func(g Gomega)` argument, all assertions inside must use the `g` Gomega instance. Using the outer `Expect` causes a fatal test failure on the first failed attempt (no retry), and can panic inside the goroutine.

2. **Insufficient timeout**: The TLS handshake stat is only updated after Spire has issued a certificate and Envoy completes a TLS handshake. With SPIFFE identity propagation involved, 5s is too short.

## Why the Fix Is Stable

Using `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern — it captures failures and lets `Eventually` retry rather than failing immediately. The 30s timeout matches the first `Eventually` block in the same test, which already accounts for Spire propagation delay.

Closes #32

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)