### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,12 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially before parallel cluster starts to prevent a race condition
+	# where two parallel make subprocesses both trigger "mise which golangci-lint" at parse
+	# time and race to create the golangci-lint/latest symlink (EEXIST / "File exists").
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #34

- **Root cause**: `test/e2e/k8s/start` runs two cluster start targets (`kuma-1`, `kuma-2`) as parallel make prerequisites. Each spawns a new `make` subprocess that parses the entire Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)`. Since the e2e workflow uses `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` during initial setup, these tools are not pre-installed. Both parallel processes race to install `golangci-lint` via mise auto-install, causing a symlink conflict (`EEXIST: "File exists"`) that fails `k3d/start`.
- **What changed**: Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` serially before launching the parallel cluster starts. This ensures all tools are already installed when the parallel make subprocesses parse the Makefile.
- **Why stable**: `mise install` is idempotent — if tools are already installed it's a no-op. The sequential execution of this step before parallel cluster starts eliminates the race condition entirely.

## Test plan

- [ ] Verify CI passes on `test/e2e-multizone` target with `MISE_DISABLE_TOOLS` in the workflow
- [ ] Verify no regression in cluster start parallelism (both clusters still start in parallel after mise install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)