### PR TITLE
fix(e2e): use g.Expect inside Eventually and increase timeout in spire TLS check

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Summary

Fixes flaky test: `kubernetes/meshidentity/spire It` (issue #32)

## Root Cause

The second `Eventually` block (checking TLS handshake stats) had two bugs:

1. **Wrong Gomega usage**: Inner assertions used `Expect(err)` and `Expect(s)` (outer Gomega) instead of `g.Expect(err)` and `g.Expect(s)`. When `Eventually` receives a `func(g Gomega)` argument, all assertions inside must use the `g` instance. Using the outer `Expect` causes an immediate fatal failure on the first attempt — `Eventually` never gets a chance to retry.

2. **Insufficient timeout**: The TLS handshake stat (`listener.*_80.ssl.handshake`) is only updated after Spire has issued a certificate and Envoy has completed a TLS handshake. 5s is too short for SPIFFE identity propagation.

## What Changed

In `test/e2e_env/kubernetes/meshidentity/spire.go`:
- `Expect(err)` → `g.Expect(err)` inside `Eventually(func(g Gomega))`
- `Expect(s)` → `g.Expect(s)` inside `Eventually(func(g Gomega))`
- Timeout increased from `"5s"` to `"30s"`

## Why the Fix Is Stable

Using `g.Expect` inside `Eventually(func(g Gomega))` is the required Gomega pattern — it captures assertion failures and lets `Eventually` retry rather than panicking. The 30s timeout matches the first `Eventually` block in the same test that already accounts for Spire propagation delay.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)