### PR TITLE
fix(e2e): increase traffic check timeout and fix g.Expect in spire test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "90s", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",
@@ -130,8 +130,8 @@ spec:
 		// and it's a tls traffic
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Root Cause

After deploying `test-server` and `demo-client` in the `It` block, the SPIRE agent must detect each new pod, attest it against the `ClusterSPIFFEID`, and issue a SVID. The Kuma sidecar then picks up the SVID via the CSI driver before mTLS traffic can flow. In a loaded CI environment this full attestation cycle consistently takes longer than 30 seconds, causing the `Eventually` at line 122 to time out.

## What Changed

1. **Traffic check timeout** (`spire.go:122`): Increased the `Eventually` timeout from `"30s"` to `"90s"`. The `MustPassRepeatedly(5)` constraint is left in place — it still requires 5 consecutive successes before declaring victory, preventing a false pass from a transient success mid-attestation.

2. **Fix `Expect` → `g.Expect` in second `Eventually`** (`spire.go:133-134`): The TLS-stats check used the global `Expect` inside a `func(g Gomega)` callback. Global `Expect` panics on failure instead of causing the `Eventually` to retry, which means a transient `GetStats` error would abort the test rather than retrying. Switched to `g.Expect` and increased the timeout from `"5s"` to `"30s"` to give the TLS handshake stats time to accumulate after traffic starts flowing.

## Why the Fix Is Stable

- 90 seconds gives SPIRE ample time to complete pod attestation even on heavily loaded CI runners, while still being well within the overall test budget.
- Using `g.Expect` inside `Eventually` is the required pattern per the project's e2e-testing guidelines; it retries on any failure rather than panicking.
- The `MustPassRepeatedly(5)` guard on the first check ensures the test only passes once traffic is genuinely stable, not just for a single lucky request.

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)