### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,12 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially before parallel cluster starts to prevent a race condition
+	# where two parallel make subprocesses both trigger "mise which <tool>" at parse time
+	# and race to create the tool's latest symlink (EEXIST / "File exists").
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #16

- **Root cause**: `test/e2e/k8s/start` runs `K8SCLUSTERS_START_TARGETS` (e.g. `kuma-1` and `kuma-2`) as parallel make prerequisites. Each spawned make subprocess parses the entire Makefile at startup, evaluating `$(shell $(MISE) which <tool>)` expressions. If tools like `skaffold` or `golangci-lint` are not pre-installed (because `MISE_DISABLE_TOOLS` was set during initial setup or the tools were otherwise skipped), mise auto-install fires in both processes simultaneously. Both processes then race to rebuild runtime symlinks, and the second process fails with: `mise ERROR failed to ln -sf ./2.18.0 .../skaffold/latest` / `File exists (os error 17)`.
- **What changed**: Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` serially before launching the parallel cluster start targets. This ensures all tools are already installed when the parallel make subprocesses parse the Makefile.
- **Why stable**: `mise install` is idempotent — if tools are already installed it is a no-op. The sequential execution of this step before parallel cluster starts eliminates the race condition entirely. This fix applies to both `test/e2e-kubernetes` (sidecarContainers, issue #16) and `test/e2e-multizone` (issue #34) since both go through `test/e2e/k8s/start`.

## Test plan

- [ ] Verify CI passes on `test/e2e-kubernetes` with sidecarContainers target
- [ ] Verify no regression in cluster start parallelism (both clusters still start in parallel after mise install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)