### PR TITLE
fix(e2e): increase spire traffic check timeout to 90s

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "90s", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",


### PR DESCRIPTION
## Root Cause

After deploying `test-server` and `demo-client` in the `It` block, SPIRE must attest each new pod against the `ClusterSPIFFEID` and issue a SVID. The Kuma sidecar then picks up the SVID via the CSI driver before mTLS traffic can flow. On loaded CI runners this full attestation cycle can exceed 30 seconds, causing the `Eventually` at line 122 to time out even though the system is healthy and would eventually succeed.

## What Changed

In `test/e2e_env/kubernetes/meshidentity/spire.go`:
- Increased the first `Eventually` timeout (traffic check) from `"30s"` to `"90s"` to give SPIRE enough time to complete pod attestation and SVID issuance on slow CI runners.

Note: `g.Expect` and the 30s timeout for the TLS-stats `Eventually` were already fixed in a prior commit (96aea0b).

## Why the Fix Is Stable

- 90 seconds gives SPIRE ample time to complete pod attestation even on heavily loaded CI runners.
- The `MustPassRepeatedly(5)` guard on the traffic check remains in place — it still requires 5 consecutive successes before declaring victory, preventing a false pass from a transient success mid-attestation.
- This timeout matches common patterns used in other SPIRE-dependent tests that need to account for cert issuance delays.

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)