### PR TITLE
fix(kds): document IPv4 loopback requirement in full sync test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -75,6 +75,9 @@ var _ = Describe("Full sync tests", func() {
 		// starting zone CPs. Without this, zone mux clients can hit "connection
 		// refused" on their first dial and trigger the resilient component's base
 		// backoff (5s), consuming most of the 30s Eventually window for sync verification.
+		// Use 127.0.0.1 (IPv4 loopback) explicitly rather than "localhost": on many
+		// Linux systems "localhost" resolves to ::1 (IPv6) first, which fails when the
+		// gRPC server only binds to 0.0.0.0 (IPv4).
 		Eventually(func() error {
 			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", globalPort), time.Second)
 			if err != nil {


### PR DESCRIPTION
## Summary

- Adds a comment explaining why `127.0.0.1` must be used instead of `"localhost"` when polling the global CP's gRPC port in `full_sync_test.go`
- On many Linux systems `"localhost"` resolves to `::1` (IPv6) first, causing `net.Dial` to fail when the gRPC server only binds to `0.0.0.0` (IPv4)
- Prevents future regressions from inadvertently reverting the address to `"localhost"`

Closes #33

## Root Cause

The flaky test `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled` in `pkg/kds/context/full_sync_test.go` had two interacting problems:

1. Zone CPs were started immediately after spawning the global CP goroutine, before `net.Listen` was called on the gRPC port. Zone mux clients hit `"connection refused"`, triggering `ResilientComponentBaseBackoff` (5-second base delay), consuming most of the 30-second `Eventually` window for zone sync verification.
2. The original code used `"localhost"` which on many Linux systems resolves to `::1` (IPv6), causing connection failures when the server only listens on IPv4.

## What Changed

The core fixes (waiting for the port + using `127.0.0.1`) were already applied in commits `88b348fdf` and `8b97f6895`. This PR adds a comment explaining **why** `127.0.0.1` must be used to prevent future regressions.

## Why the Fix Is Stable

Zone CPs only start after the global gRPC server is confirmed to be accepting TCP connections on `127.0.0.1`. Using the explicit IPv4 loopback address ensures the dial matches the server's bound address regardless of how the OS resolves `"localhost"`.

## Test plan

- [ ] `make format && make check` passes
- [ ] `make test TEST_PKG_LIST=./pkg/kds/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)