### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,12 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially before parallel cluster starts to prevent a race condition
+	# where two parallel make subprocesses both evaluate $(shell $(MISE) which <tool>) at
+	# parse time and race to rebuild runtime symlinks (EEXIST / "File exists").
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #34

- **Root cause**: `test/e2e/k8s/start` ran `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned `make` subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)`. Since `golangci-lint` and `skaffold` are not pre-installed in the e2e workflow (disabled via `MISE_DISABLE_TOOLS` only during the `jdx/mise-action` step), mise auto-install triggered in both parallel processes simultaneously. Both then raced to rebuild runtime symlinks, with the second process failing: `EEXIST: File exists`.
- **What changed**: Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` as an explicit serial step before invoking `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` in parallel. The `K8SCLUSTERS_LOAD_IMAGES_TARGETS` step remains after cluster starts as before.
- **Why stable**: `mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely regardless of which tools were or weren't installed during earlier workflow steps.

## Test plan

- [ ] Verify CI passes on `test/e2e-multizone` target
- [ ] Verify no regression in cluster start parallelism (both clusters still start in parallel after mise install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)