### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,12 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially before parallel cluster starts to prevent a race condition
+	# where two parallel make subprocesses both trigger "mise which <tool>" at parse time
+	# and race to create the tool's latest symlink (EEXIST / "File exists").
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
Fixes #34
Fixes #16

## Root Cause

`test/e2e/k8s/start` listed `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned make subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which <tool>)` expressions. Since the e2e workflow uses `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` during the `jdx/mise-action` step, those tools are not pre-installed. When both parallel subprocesses evaluate `mise which golangci-lint` (or `mise which skaffold`), mise's auto-install fires in both simultaneously. Both processes then race to rebuild the tool's runtime symlinks, and the second process fails with:

```
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
```

This affects both the `multizone` (issue #34) and `sidecarContainers` (issue #16) e2e targets since both go through `test/e2e/k8s/start`.

## What Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` as an explicit serial step before invoking `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` in parallel.

## Why the Fix Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed when the parallel make subprocesses parse the Makefile, so neither subprocess triggers mise auto-install. This eliminates the race condition entirely regardless of which tools were or weren't installed during earlier workflow steps.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)