### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MISE) install # ensure all tools are installed before parallel cluster starts
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes flaky tests in issues #34 and #16 (both caused by the same race condition).

- Added `$(MISE) install` as a serial step before invoking parallel cluster starts in `test/e2e/k8s/start`

## Root Cause

`test/e2e/k8s/start` ran `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned `make` subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` (in `mk/dev.mk`). Since `golangci-lint` and `skaffold` are not pre-installed in the e2e workflow (`MISE_DISABLE_TOOLS` only applied to the `jdx/mise-action` step, not the "Run E2E tests" step), mise's auto-install triggered in both parallel processes simultaneously. Both then raced to rebuild runtime symlinks, with the second process failing:

```
mise ERROR failed to rebuild runtime symlinks
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
```

## What Was Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` as an explicit serial step before invoking `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` in parallel. The `K8SCLUSTERS_LOAD_IMAGES_TARGETS` step remains after cluster starts as before.

## Why the Fix Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely regardless of which tools were or weren't installed during earlier workflow steps.

Closes #34
Closes #16

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)