### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,11 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially first to avoid a race condition where parallel make
+	# subprocesses both trigger mise auto-install and race to create tool symlinks
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes the mise parallel symlink race condition causing flaky e2e tests (issues #34 and #16).

- Run `$(MISE) install` serially before invoking `$(MAKE) $(K8SCLUSTERS_START_TARGETS)`
- Remove `$(K8SCLUSTERS_START_TARGETS)` as a parallel make prerequisite (now called via `$(MAKE)` after install)

## Root Cause

`test/e2e/k8s/start` listed `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned make subprocess parsed the full Makefile, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`.

The `jdx/mise-action` step sets `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"`, but this env var only applies to that step — the "Run E2E tests" step doesn't inherit it. So golangci-lint and skaffold are not pre-installed when parallel `k3d` cluster starts trigger. Both subprocesses call `mise which golangci-lint`, triggering auto-install simultaneously, then race to rebuild runtime symlinks:

```
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
```

## Why the fix is stable

`$(MISE) install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely regardless of which tools were or weren't installed during earlier workflow steps.

Closes #34
Closes #16

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)