### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MISE) install # ensure all tools are installed before parallel subprocesses parse the Makefile
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
Fixes #34, #16

## Summary

- Added `$(MISE) install` as a serial step before `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` in `test/e2e/k8s/start`
- Moved cluster start targets from make prerequisites to an explicit `$(MAKE)` call to ensure serial execution order

## Root Cause

`test/e2e/k8s/start` listed `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned `make` subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` and `$(shell $(MISE) which skaffold)`. Since `MISE_DISABLE_TOOLS` in the `jdx/mise-action` step doesn't carry over to the "Run E2E tests" step, mise auto-install triggered in both parallel processes simultaneously. Both then raced to rebuild runtime symlinks, with the second failing:

```
mise ERROR failed to rebuild runtime symlinks
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
```

## What Was Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk`:
1. Runs `$(MISE) install` as an explicit serial step before cluster starts
2. Changed `$(K8SCLUSTERS_START_TARGETS)` from make prerequisites to an explicit `$(MAKE)` invocation

## Why This Fix Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely.

Note: Issue #36 referenced in the fix task does not exist in this repo — this fix was applied against issues #34 and #16 (the actual open flaky test issues with this root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)