### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MISE) install # ensure all tools are installed before parallel cluster starts to avoid mise symlink race
+	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

- Fixes a race condition where two parallel make subprocesses both trigger `mise` auto-install of `golangci-lint` simultaneously
- Add `$(MISE) install` as a serial step before starting clusters in parallel in `test/e2e/k8s/start`

## Root Cause

The e2e workflow sets `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` in the `jdx/mise-action` step, so those tools are **not** installed. When `test/e2e/k8s/start` runs with `make -j2`, it starts `kuma-1` and `kuma-2` clusters in parallel (as make prerequisites). Each spawned subprocess parses the full Makefile, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk:78`. Both subprocesses trigger mise auto-install simultaneously and race to create the symlink:

```
mise ERROR failed to rebuild runtime symlinks
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## What Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk`:
1. Removed `$(K8SCLUSTERS_START_TARGETS)` as make prerequisites (which ran in parallel via jobserver)
2. Added `$(MISE) install` as an explicit serial step before cluster starts
3. Changed to explicit `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` to preserve parallel cluster startup

## Why the Fix is Stable

`$(MISE) install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed (including `golangci-lint`), so neither subprocess needs to trigger mise auto-install when parsing the Makefile. This eliminates the symlink race condition entirely.

Closes #34
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)