### PR TITLE
fix(e2e): wait for spire-controller-manager webhook endpoints before proceeding

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -1,8 +1,12 @@
 package spire
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -73,7 +77,35 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
-	return nil
+	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
+}
+
+// waitForWebhookEndpoints polls the named Endpoints object until it has at least
+// one ready address. The spire-controller-manager runs as a sidecar inside the
+// spire-server pod (no standalone pod), so we cannot use isPodReady for it.
+// The admission webhook for ClusterSPIFFEID resources is only usable once the
+// endpoint controller has populated the service's endpoint slice.
+func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, serviceName string) error {
+	clientset, err := k8s.GetKubernetesClientFromOptionsE(cluster.GetTesting(), cluster.GetKubectlOptions(t.namespace))
+	if err != nil {
+		return err
+	}
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for webhook endpoints %s", serviceName),
+		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultTimeout,
+		func() (string, error) {
+			ep, err := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			for _, subset := range ep.Subsets {
+				if len(subset.Addresses) > 0 {
+					return "ready", nil
+				}
+			}
+			return "", errors.Errorf("no ready endpoints for service %q in namespace %q", serviceName, t.namespace)
+		})
+	return err
 }
 
 func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) error {


### PR DESCRIPTION
## Summary

- Adds `waitForWebhookEndpoints` to `test/framework/deployments/spire/kubernetes.go` that polls the Kubernetes Endpoints API for `spire-controller-manager-webhook` until at least one ready address appears before `Deploy` returns
- Removes the race condition where `ClusterSPIFFEID` was applied before the webhook endpoint was available

Fixes #31

> Changelog: skip

## Root Cause

The `BeforeAll` setup calls `spire.Install()` (which invokes `Deploy`), then immediately applies a `ClusterSPIFFEID` via `YamlK8s(workflowRegistration)`. The `vclusterspiffeid.kb.io` admission webhook — which validates `ClusterSPIFFEID` resources — is hosted by the `spire-controller-manager` sidecar running inside `spire-server-0`.

After the `spire-server` pod becomes Available, Kubernetes' endpoint controller may not have propagated the pod's readiness to the `spire-controller-manager-webhook` Service endpoints yet. When `BeforeAll` applied the `ClusterSPIFFEID` in this window, the admission webhook rejected it:

```
Internal error occurred: failed calling webhook "vclusterspiffeid.kb.io":
no endpoints available for service "spire-controller-manager-webhook"
```

Previous fix attempts tried `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` but this caused a 270-second hang (90 retries × 3s) because no standalone pod with that selector exists — the controller-manager is a sidecar, not its own Deployment.

## What Changed

Added `waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")` at the end of `Deploy`. It:
1. Gets a Kubernetes clientset
2. Polls `clientset.CoreV1().Endpoints(namespace).Get(...)` in a retry loop (DefaultRetries×3, DefaultTimeout intervals — matching the other SPIRE component waits)
3. Returns success as soon as at least one ready address exists in any endpoint subset

This directly observes the state that matters — whether the webhook service has endpoints — without relying on a pod that doesn't exist.

## Why This Is Stable

Polling the Endpoints object directly is the authoritative signal that the webhook is usable. Once the endpoint controller publishes at least one ready address for `spire-controller-manager-webhook`, Kubernetes will route admission requests to it. The retry loop (90 retries × 3s = 270s max) gives ample time for propagation even on slow CI runners.

## Test plan

- [ ] CI passes with `ci/verify-stability` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)