### PR TITLE
fix(e2e): add MeshIdentity readiness gate and increase timeouts in spire test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -2,7 +2,9 @@ package meshidentity
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -113,13 +115,28 @@ spec:
 			)).
 			Setup(kubernetes.Cluster)).To(Succeed())
 
+		// wait for MeshIdentity to be reconciled by SPIRE provider before checking traffic
+		isMeshIdentityReady := func(name string) (bool, error) {
+			GinkgoHelper()
+			output, err := k8s.RunKubectlAndGetOutputE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(Config.KumaNamespace), "get", "meshidentity", name, "-ojson")
+			if err != nil {
+				return false, err
+			}
+			return strings.Contains(output, "PartiallyReady") || strings.Contains(output, "Successfully initialized"), nil
+		}
+		Eventually(func(g Gomega) {
+			isReady, err := isMeshIdentityReady("identity-spire")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(isReady).To(BeTrue())
+		}, "2m", "1s").Should(Succeed())
+
 		// then
 		// traffic works
 		Eventually(func(g Gomega) {
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",


### PR DESCRIPTION
## Root Cause

The previous fix (commit `96aea0bef`) corrected `g.Expect` usage in the TLS stats `Eventually` block and increased that timeout from 5s to 30s. However, the traffic check still had only a 30s window — on loaded CI runners, SPIRE attestation and SVID issuance can easily take longer than 30s, causing the `Eventually` to time out before mTLS is active.

The full pipeline that must complete before traffic can flow:
1. Pods start up with the SPIRE sidecar annotation
2. SPIRE attests each pod against the `ClusterSPIFFEID`
3. SPIRE issues SVID certificates to the workloads via CSI driver
4. Envoy picks up the SVIDs via SDS and reconfigures mTLS
5. Only then does mTLS traffic succeed

## What Changed

In `test/e2e_env/kubernetes/meshidentity/spire.go`:
- **Add MeshIdentity readiness gate**: polls `kubectl get meshidentity identity-spire -ojson` for `"PartiallyReady"` or `"Successfully initialized"` status (up to 2m) before the traffic check. This ensures SPIRE has completed pod attestation and SVID issuance before traffic is verified.
- **Increase traffic `Eventually` timeout from `30s` to `2m`**: gives additional buffer for SVID issuance and Envoy SDS reconfiguration on slow CI runners.

## Why the Fix Should Be Stable

- The readiness gate directly observes the SPIRE-provider reconciliation status, eliminating the race between "workloads deployed" and "SVIDs issued and mTLS active". Traffic checks now only run when the system is actually ready.
- The `MustPassRepeatedly(5)` guard on the traffic check remains, requiring 5 consecutive successes before declaring victory.
- 2m timeout gives ample time even for heavily loaded CI runners.

Fixes #32

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)