### PR TITLE
fix(e2e): increase spire traffic check timeout to 60s

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "60s", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",


### PR DESCRIPTION
## Root Cause

The `Eventually` block checking that traffic works (lines 118–122) had a **30-second timeout**. When SPIRE is involved, the full certificate-issuance chain must complete before mTLS traffic can succeed:

1. Pods start with the SPIRE sidecar annotation
2. SPIRE attests each pod against the `ClusterSPIFFEID`
3. SPIRE issues SVID certificates via the CSI driver
4. Envoy picks up the SVIDs via SDS and reconfigures mTLS
5. Only then does mTLS traffic work

On loaded CI runners this pipeline can take well over 30 seconds. Combined with `MustPassRepeatedly(5)` (requiring 5 consecutive successes), there is insufficient headroom — even if SPIRE finishes at second 27, there's no time left for 5 more successful requests.

The `g.Expect` fix and 30s TLS-stats timeout were already addressed by commit `96aea0bef`.

## What Changed

In `test/e2e_env/kubernetes/meshidentity/spire.go`:
- Increased the traffic check `Eventually` timeout from `"30s"` to `"60s"`

## Why the Fix Should Be Stable

60 seconds gives SPIRE enough time to complete pod attestation and SVID issuance even on heavily loaded CI runners. The `MustPassRepeatedly(5)` guard remains unchanged, still requiring 5 consecutive successes before declaring victory.

Fixes #32

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)