### PR TITLE
fix(e2e): fix remaining flaky spire meshidentity test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",

--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -68,10 +68,6 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spiffe-oidc-discovery-provider")
-	if err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes the remaining flakiness in `kubernetes/meshidentity/spire It` (issue #32) that persisted after the initial fix in commit `96aea0bef`.

## Root Cause

Two issues were still causing failures:

1. **`spiffe-oidc-discovery-provider` pod readiness check in `kubernetes.go`** (BeforeAll flake): `isPodReady` was called with selector `app.kubernetes.io/name=spiffe-oidc-discovery-provider`, but this component is not deployed as a standalone pod in the current SPIRE hardened helm chart. No pod matches this selector, so `WaitUntilNumPodsCreatedE` always timed out after 90 retries (~4.5 min), failing `BeforeAll`. This was confirmed across multiple CI failures (PRs #36, #40, #46, #48, #50, #51) with:
   ```
   'Wait for num pods created to match desired count 1.' unsuccessful after 90 retries
   ```

2. **Traffic check timeout too short in `spire.go`**: The `Eventually` block at line 118-122 used a 30s timeout with `MustPassRepeatedly(5)`. The full SPIRE mTLS pipeline — pod attestation → SVID issuance → Envoy SDS reconfiguration — can exceed 30s on loaded CI runners, causing:
   ```
   Timed out after 30.001s.
   The function passed to Eventually failed at spire.go:120 with:
   Unexpected error: stderr: 'curl: (22) The requested URL returned error: 503'
   ```

## What Changed

- `test/framework/deployments/spire/kubernetes.go`: Removed the `spiffe-oidc-discovery-provider` readiness check. This component is not deployed as a standalone pod in the SPIRE hardened helm chart — waiting for it always times out. The agent, server, and CSI driver checks are sufficient to ensure SPIRE is ready.

- `test/e2e_env/kubernetes/meshidentity/spire.go`: Increased traffic check `Eventually` timeout from `"30s"` to `"2m"` to give SPIRE enough time to complete the full attestation cycle (pod attestation → SVID issuance → Envoy certificate pickup via SDS) even on heavily loaded CI runners.

## Why the Fix Is Stable

- Removing the `spiffe-oidc-discovery-provider` check eliminates a guaranteed `BeforeAll` failure since no pod with that label exists. The server readiness check already ensures SPIRE is operational.
- 2 minutes gives substantial headroom for the SPIRE attestation pipeline without making the test unreasonably slow. The previous 30s was confirmed insufficient in multiple CI runs.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)