### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,12 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially before parallel cluster starts to prevent a race condition
+	# where two parallel make subprocesses both trigger mise tool installation simultaneously
+	# and race to create runtime symlinks (EEXIST / "File exists" error).
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #16

- **Root cause**: `test/e2e/k8s/start` listed `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned make subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which skaffold)`. Since the e2e workflow uses `MISE_DISABLE_TOOLS` during initial mise-action setup, those tools are not pre-installed in subsequent steps. Both parallel subprocesses triggered mise auto-install simultaneously and raced to create the runtime symlink:
  ```
  mise ERROR failed to ln -sf ./2.18.0 /home/ubuntu/.local/share/mise/installs/skaffold/latest
  mise ERROR File exists (os error 17)
  make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
  ```
- **What changed**: Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` as an explicit serial step before invoking `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` in parallel.
- **Why stable**: `$(MISE) install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install. This eliminates the race condition entirely.

## Test plan

- [ ] Verify CI passes on `test_e2e_env (sidecarContainers, v1.34.1-k3s1, kubernetes, amd64)` without the `mise ERROR File exists` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)