### PR TITLE
fix(ci): run mise install before parallel k3d cluster starts to fix EEXIST race

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,15 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially first to avoid a race condition: when make -j2 starts
+	# kuma-1 and kuma-2 clusters in parallel, each subprocess parses the Makefile and
+	# evaluates $(shell $(MISE) which golangci-lint). If golangci-lint is not pre-installed,
+	# both subprocesses trigger mise auto-install simultaneously and race to rebuild
+	# runtime symlinks, failing with EEXIST. Running mise install once before the parallel
+	# start ensures all tools are present and no auto-install is triggered.
+	$(MISE) install
+	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

- Fixes race condition causing `mise ERROR File exists (os error 17)` in multizone e2e tests
- Run `$(MISE) install` serially before starting k8s clusters in parallel in `test/e2e/k8s/start`

## Root Cause

The CI workflow runs `make -j2 CI=true test/e2e-multizone` for amd64. With `-j2`, the make jobserver propagates to sub-makes, so `test/e2e/k8s/start`'s prerequisites (`kuma-1`, `kuma-2`) start in parallel.

Each spawned `make` subprocess parses the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk:78`. Since `MISE_DISABLE_TOOLS="golangci-lint,skaffold"` is set only in the `jdx/mise-action` step (not in "Run E2E tests"), `golangci-lint` is not pre-installed. Both parallel subprocesses trigger mise auto-install simultaneously and race to rebuild runtime symlinks:

```
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
make: *** [mk/e2e.new.mk:170: test/e2e-multizone] Error 2
```

## What Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk`:
1. Moved `$(K8SCLUSTERS_START_TARGETS)` from prerequisites to an explicit `$(MAKE) -j` command (preserving parallel cluster startup)
2. Added `$(MISE) install` as a serial step before the parallel cluster starts

## Why the Fix is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely regardless of which tools were or weren't installed during earlier workflow steps.

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)