### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Root Cause

`test/e2e/k8s/start` listed `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned make subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` (and other tools) in `mk/dev.mk`. Since `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` is only set on the `jdx/mise-action` step and does **not** carry over to the "Run E2E tests" step, mise's auto-install triggered in both parallel processes simultaneously. Both then raced to rebuild runtime symlinks, with the second process failing:

```
mise ERROR failed to rebuild runtime symlinks
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
```

## What Was Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk`:
1. Removed `$(K8SCLUSTERS_START_TARGETS)` from make prerequisites (previously they ran in parallel under the jobserver)
2. Added `$(MISE) install` as an explicit serial recipe step that runs first
3. Added `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` as an explicit call in the recipe body (parallelism is inherited from the parent `-j` flag)

## Why This Fix Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools (including golangci-lint and skaffold) have their symlinks fully built before any parallel subprocess evaluates `$(shell $(MISE) which ...)`. This eliminates the race condition entirely.

Fixes #34, #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)