### PR TITLE
fix(e2e): run mise install serially before parallel cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,14 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially first to prevent a race condition: when make -j2 starts
+	# kuma-1 and kuma-2 in parallel, each subprocess parses the Makefile and evaluates
+	# $(shell $(MISE) which golangci-lint). If golangci-lint is not pre-installed, both
+	# subprocesses trigger mise auto-install simultaneously and race to rebuild symlinks,
+	# failing with EEXIST. Running mise install once serially ensures all tools are present.
+	$(MISE) install
+	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
Fixes #34

## Root Cause

When running `make -j2 CI=true test/e2e-multizone`, the make jobserver propagates `-j2` to sub-makes. `test/e2e/k8s/start` had `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel prerequisites, so both cluster start processes launched simultaneously.

Each spawned `make` subprocess parses the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk:78`. Since `MISE_DISABLE_TOOLS="golangci-lint,skaffold"` only applies to the `jdx/mise-action` step (not to "Run E2E tests"), golangci-lint is not pre-installed. Both parallel subprocesses trigger mise auto-install simultaneously and race to rebuild runtime symlinks:

\`\`\`
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
make: *** [mk/e2e.new.mk:170: test/e2e-multizone] Error 2
\`\`\`

## What Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk`:
1. Moved `$(K8SCLUSTERS_START_TARGETS)` from prerequisites to an explicit `$(MAKE) -j` recipe command (preserving parallel cluster startup)
2. Added `$(MISE) install` as a serial step before the parallel cluster starts

## Why the Fix Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely regardless of which tools were or weren't installed during earlier workflow steps.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)