### PR TITLE
fix(kds): reduce resilient component backoff and document IPv4 loopback in full sync test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -63,6 +63,11 @@ var _ = Describe("Full sync tests", func() {
 		cfg.Multizone.Global.KDS.TlsEnabled = false
 		cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 		cfg.Mode = config_core.Global
+		// Reduce resilient component backoff so that any transient connection failure
+		// causes a fast reconnect rather than the default 5s base backoff, which would
+		// consume most of the 30s Eventually window for sync verification.
+		cfg.General.ResilientComponentBaseBackoff = config_types.Duration{Duration: 100 * time.Millisecond}
+		cfg.General.ResilientComponentMaxBackoff = config_types.Duration{Duration: 5 * time.Second}
 		rt := setup.NewTestRuntime(ctx, cfg, globalStore)
 		Expect(global.Setup(rt)).To(Succeed())
 		wg.Add(1)
@@ -75,6 +80,9 @@ var _ = Describe("Full sync tests", func() {
 		// starting zone CPs. Without this, zone mux clients can hit "connection
 		// refused" on their first dial and trigger the resilient component's base
 		// backoff (5s), consuming most of the 30s Eventually window for sync verification.
+		// Use 127.0.0.1 (IPv4 loopback) explicitly rather than "localhost": on many
+		// Linux systems "localhost" resolves to ::1 (IPv6) first, which fails when the
+		// gRPC server only binds to 0.0.0.0 (IPv4).
 		Eventually(func() error {
 			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", globalPort), time.Second)
 			if err != nil {
@@ -92,8 +100,14 @@ var _ = Describe("Full sync tests", func() {
 			cfg.Store.Type = config_store.MemoryStore
 			cfg.Mode = config_core.Zone
 			cfg.Multizone.Zone.Name = zoneName
+			// Use 127.0.0.1 (IPv4 loopback) explicitly rather than "localhost": on many
+			// Linux systems "localhost" resolves to ::1 (IPv6) first, which fails when the
+			// gRPC server only binds to 0.0.0.0 (IPv4).
 			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
 			cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+			// Same as global: reduce resilient component backoff so reconnects are fast.
+			cfg.General.ResilientComponentBaseBackoff = config_types.Duration{Duration: 100 * time.Millisecond}
+			cfg.General.ResilientComponentMaxBackoff = config_types.Duration{Duration: 5 * time.Second}
 			rt := setup.NewTestRuntime(ctx, cfg, zoneStore)
 			Expect(zone.Setup(rt)).To(Succeed())
 			wg.Add(1)


### PR DESCRIPTION
## Summary

- Reduces `ResilientComponentBaseBackoff` from 5s → 100ms and `ResilientComponentMaxBackoff` from 1min → 5s for both global and zone CPs in `full_sync_test.go`
- Adds explanatory comments at both `127.0.0.1` usage sites explaining the IPv6 resolution hazard

Closes #33

## Root Cause

The flaky test `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled` failed when zone-1's mux client hit **connection refused** on its first dial attempt (IPv6 `[::1]` while the gRPC server was IPv4-only). This triggered the resilient component's default **5-second base backoff**. With a 30s `Eventually` window, only ~5 retry opportunities remained — insufficient on a loaded CI machine.

Two prior commits (`88b348fdf`, `8b97f6895`) fixed the primary races:
1. Added an `Eventually` port-readiness check before starting zone CPs
2. Changed `"localhost"` → `"127.0.0.1"` to avoid IPv6 resolution

## What Changed

**Defense-in-depth**: reduces `ResilientComponentBaseBackoff` from 5s to 100ms (and max from 1min to 5s) for all CPs in the test. If any transient connection failure still occurs on a slow CI runner, zone CPs retry within ~100ms instead of burning 5s of the 30s `Eventually` window — giving ~300 retry opportunities instead of ~5.

**Documentation**: adds comments explaining why `127.0.0.1` must be used instead of `"localhost"` at both the port-readiness check and the zone `GlobalAddress` config, preventing future regressions.

## Why the Fix Is Stable

- The port-readiness check is the primary guard against the race
- `127.0.0.1` prevents IPv6 mismatches on Linux runners
- The reduced backoff is a safety net: even if a zone fails to connect on its first attempt, it reconnects within ~100ms, ensuring sync completes well within the 30s window
- All changes are test-only and do not affect production behavior

## Test plan

- [ ] `make format && make check` passes
- [ ] `make test TEST_PKG_LIST=./pkg/kds/context/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)