### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,10 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Run mise install serially first so parallel sub-makes don't race to install tools
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #34

- Runs `$(MISE) install` serially before starting k3d clusters in `test/e2e/k8s/start`
- Moves `$(K8SCLUSTERS_START_TARGETS)` from make prerequisites into the recipe body

## Root Cause

When `make -j2 CI=true test/e2e-multizone` runs, it calls `$(MAKE) test/e2e/k8s/start`. Inside that target, `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) were listed as **make prerequisites**, so with `-j2` inherited they ran in parallel.

Each parallel sub-make process parses the full Makefile at startup, evaluating `GOLANGCI_LINT=$(shell mise which golangci-lint)` in `mk/dev.mk:78`. Since `golangci-lint` is not pre-installed in the e2e workflow (`MISE_DISABLE_TOOLS="golangci-lint,skaffold"` is only set in the `jdx/mise-action` step, not in the "Run E2E tests" step), mise auto-installs it in both processes simultaneously. Both then race to rebuild runtime symlinks:

```
mise Cannot parse Rekor public key ...
mise ERROR File exists (os error 17)
make[2]: *** [mk/e2e.new.mk:82: k3d/start] Error 1
```

## What Was Changed

`mk/e2e.new.mk` — changed `test/e2e/k8s/start` from using prerequisites (which inherit `-j2` parallelism) to an explicit recipe that runs `$(MISE) install` first, then `$(MAKE) $(K8SCLUSTERS_START_TARGETS)`.

## Why This Is Stable

`mise install` is idempotent — it is a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools have their symlinks built before any parallel subprocess evaluates `$(shell mise which ...)`. This eliminates the race condition entirely regardless of how many tools were or weren't installed during earlier workflow steps.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)