### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #34

- Runs `$(MISE) install` serially before starting k3d clusters in `test/e2e/k8s/start`
- Moves `$(K8SCLUSTERS_START_TARGETS)` from make prerequisites into the recipe body

## Root Cause

When `make -j2 CI=true test/e2e-multizone` runs, it calls `$(MAKE) test/e2e/k8s/start`. Inside that target, `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) were listed as **make prerequisites**, so with `-j2` inherited they ran in parallel.

Each parallel sub-make process parses the full Makefile at startup, and any call to `$(MISE)` (e.g. `$(MISE) which k3d`) triggers mise to also rebuild runtime symlinks for all installed tools. Since `golangci-lint` is not pre-installed in the e2e workflow (`MISE_DISABLE_TOOLS="golangci-lint,skaffold"` is only set in the `jdx/mise-action` step, not in the "Run E2E tests" step), both processes race to rebuild the `golangci-lint/latest` symlink:

```
mise ERROR failed to rebuild runtime symlinks
mise ERROR failed to ln -sf ./2.11.3 .../golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/e2e.new.mk:82: k3d/start] Error 1
```

## What Was Changed

`mk/e2e.new.mk` — changed `test/e2e/k8s/start` from using prerequisites (which inherit `-j2` parallelism) to an explicit recipe that:
1. Runs `$(MISE) install` first (serial, installs all tools and builds symlinks once)
2. Then runs `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` (parallel cluster starts)
3. Then runs `$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS)` (as before)

## Why This Is Stable

`mise install` is idempotent — it is a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools have their symlinks built before any parallel subprocess calls mise, eliminating the race condition entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)