### PR TITLE
fix(e2e): serialize k8s cluster starts to avoid mise symlink race

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,10 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+# Run cluster starts sequentially to avoid a race condition where concurrent sub-make processes
+# trigger parallel 'mise install' invocations that race on creating tool symlinks (e.g. golangci-lint/latest).
+test/e2e/k8s/start:
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

- Changes `test/e2e/k8s/start` to run `kuma-1` and `kuma-2` cluster starts sequentially instead of as parallel prerequisites
- Prevents concurrent `mise install` invocations that race on creating tool symlinks

## Root Cause

When `test/e2e/k8s/start` listed both cluster start targets as **prerequisites**, they could run in parallel because `-j` propagates via `MAKEFLAGS` from the outer CI make invocation.

Each parallel sub-make process evaluated all `$(shell $(MISE) which <tool>)` assignments in `mk/dev.mk` at load time (e.g. `K3D_BIN`, `GOLANGCI_LINT`). This triggered concurrent `mise install` runs. Both processes raced to create the `golangci-lint/latest` symlink via `ln -sf ./2.11.3 .../golangci-lint/latest`. One succeeded; the other failed with:

```
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
```

This caused `test/e2e/k8s/start/cluster/kuma-2` to fail, aborting the entire multizone E2E run.

## What Changed

Changed from prerequisites (parallelizable):
```makefile
test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
    $(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS)
```

To sequential recipe calls:
```makefile
test/e2e/k8s/start:
    $(MAKE) $(K8SCLUSTERS_START_TARGETS)   # runs kuma-1, then kuma-2 sequentially
    $(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS)
```

When `$(MAKE)` is called with multiple command-line goals, GNU Make processes them one at a time (left to right), regardless of the `-j` setting. This ensures `kuma-1` fully starts (including mise tool installation) before `kuma-2` begins, eliminating the symlink race.

## Why This Fix Is Stable

- The race was deterministic: two concurrent sub-make processes always trigger the same conflict on the `latest` symlink
- Sequential execution guarantees only one mise invocation runs at a time during cluster setup
- The `test/e2e/debug` target (line 108) intentionally uses `$(MAKE) -j` for parallel starts — that target is for local debugging and is unaffected by this change
- Load image targets (`$(K8SCLUSTERS_LOAD_IMAGES_TARGETS)`) were already sequential; no change there

Fixes #34

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)