### PR TITLE
fix(e2e): run mise install before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,13 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Install mise tools serially before parallel cluster starts. Without this,
+	# two parallel make subprocesses both evaluate $(shell mise which golangci-lint)
+	# at parse time, triggering concurrent auto-installs that race on the
+	# golangci-lint/latest symlink (EEXIST / "File exists").
+	$(MISE) install
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #34

- **Root cause**: `test/e2e/k8s/start` ran `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned a new `make` subprocess that parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)`. Since the e2e workflow uses `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` only in the `jdx/mise-action` step (not in "Run E2E tests"), golangci-lint is not pre-installed when e2e tests run. Both parallel processes race to auto-install it via mise, then both race to rebuild runtime symlinks, with the second failing: `EEXIST: File exists`.
- **What changed**: Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` serially before invoking `$(MAKE) $(K8SCLUSTERS_START_TARGETS)`. The cluster targets are moved from prerequisites into the recipe to preserve parallel execution via recursive make.
- **Why stable**: `mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before parallel cluster starts ensures all tools are pre-installed, so no subprocess triggers mise auto-install during Makefile parsing. This eliminates the race condition entirely.

## Test plan

- [ ] Verify CI passes on `test/e2e-multizone` target with v1.31.12-k3s1
- [ ] Verify both k3d clusters still start in parallel (via `$(MAKE) $(K8SCLUSTERS_START_TARGETS)`)
- [ ] Verify no regression in other e2e targets (kubernetes, universal, gatewayapi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)