### PR TITLE
docs(kds): add comments explaining IPv4 loopback and backoff reduction in full sync test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -63,6 +63,9 @@ var _ = Describe("Full sync tests", func() {
 		cfg.Multizone.Global.KDS.TlsEnabled = false
 		cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 		cfg.Mode = config_core.Global
+		// Reduce resilient component backoff so that any transient connection failure
+		// causes a fast reconnect rather than the default 5s base backoff, which would
+		// consume most of the 30s Eventually window for sync verification.
 		cfg.General.ResilientComponentBaseBackoff = config_types.Duration{Duration: 100 * time.Millisecond}
 		cfg.General.ResilientComponentMaxBackoff = config_types.Duration{Duration: 5 * time.Second}
 		rt := setup.NewTestRuntime(ctx, cfg, globalStore)
@@ -75,8 +78,11 @@ var _ = Describe("Full sync tests", func() {
 		}()
 		// Wait for the global CP's gRPC server to be accepting connections before
 		// starting zone CPs. Without this, zone mux clients can hit "connection
-		// refused" on their first dial and trigger a resilient component backoff,
-		// delaying sync and potentially exhausting the 30s Eventually window.
+		// refused" on their first dial and trigger the resilient component's base
+		// backoff (5s), consuming most of the 30s Eventually window for sync verification.
+		// Use 127.0.0.1 (IPv4 loopback) explicitly rather than "localhost": on many
+		// Linux systems "localhost" resolves to ::1 (IPv6) first, which fails when the
+		// gRPC server only binds to 0.0.0.0 (IPv4).
 		Eventually(func() error {
 			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", globalPort), time.Second)
 			if err != nil {
@@ -94,8 +100,12 @@ var _ = Describe("Full sync tests", func() {
 			cfg.Store.Type = config_store.MemoryStore
 			cfg.Mode = config_core.Zone
 			cfg.Multizone.Zone.Name = zoneName
+			// Use 127.0.0.1 (IPv4 loopback) explicitly rather than "localhost": on many
+			// Linux systems "localhost" resolves to ::1 (IPv6) first, which fails when the
+			// gRPC server only binds to 0.0.0.0 (IPv4).
 			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
 			cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+			// Same as global: reduce resilient component backoff so reconnects are fast.
 			cfg.General.ResilientComponentBaseBackoff = config_types.Duration{Duration: 100 * time.Millisecond}
 			cfg.General.ResilientComponentMaxBackoff = config_types.Duration{Duration: 5 * time.Second}
 			rt := setup.NewTestRuntime(ctx, cfg, zoneStore)


### PR DESCRIPTION
## Summary

- Adds explanatory comments at both `127.0.0.1` usage sites in `full_sync_test.go` explaining the IPv6 resolution hazard
- Adds a comment before `ResilientComponentBaseBackoff` for the global CP explaining why the backoff is reduced

Closes #33

## Root Cause

The `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled` test was flaky due to a startup race: zone CPs dialed the global CP's gRPC port before `net.Listen` was called. If they hit "connection refused", the resilient component's default **5-second base backoff** consumed most of the 30s `Eventually` window.

A secondary issue: `localhost` on many Linux CI runners resolves to `::1` (IPv6) while the gRPC server only binds to `0.0.0.0` (IPv4), causing "connection refused" even after the server was ready.

Prior commits already fixed the races:
- `88b348fdf`: Added `Eventually` port-readiness check before starting zone CPs
- `8b97f6895`: Changed `localhost` → `127.0.0.1` to avoid IPv6 resolution
- `71a801f03`: Added `DeferCleanup` for goroutine cleanup on test failure
- `fdc8035e4`: Reduced `ResilientComponentBaseBackoff` 5s → 100ms for defense-in-depth

## What Changed

Added comments to document *why* `127.0.0.1` must be used (IPv6 resolution on Linux) and *why* the backoff is reduced (prevent burning the 30s `Eventually` window on a single failed retry). This makes the test more maintainable and prevents future regressions.

## Why the Fix Is Stable

This PR is documentation-only (comments). The functional fixes are already on `master`.

## Test plan

- [x] `make format && make check` passes
- [x] `make test TEST_PKG_LIST=./pkg/kds/context/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)