### PR TITLE
fix(e2e): wait for spire-controller-manager webhook endpoints before deploying workloads

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -1,8 +1,12 @@
 package spire
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -73,7 +77,35 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
-	return nil
+	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
+}
+
+// waitForWebhookEndpoints polls the named Endpoints object until it has at least
+// one ready address. The spire-controller-manager runs as a sidecar inside the
+// spire-server pod (no standalone pod), so we cannot use isPodReady for it.
+// The admission webhook for ClusterSPIFFEID resources is only usable once the
+// endpoint controller has populated the service's endpoint slice.
+func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, serviceName string) error {
+	clientset, err := k8s.GetKubernetesClientFromOptionsE(cluster.GetTesting(), cluster.GetKubectlOptions(t.namespace))
+	if err != nil {
+		return err
+	}
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for webhook endpoints %s", serviceName),
+		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultTimeout,
+		func() (string, error) {
+			ep, err := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			for _, subset := range ep.Subsets {
+				if len(subset.Addresses) > 0 {
+					return "ready", nil
+				}
+			}
+			return "", errors.Errorf("no ready endpoints for service %q in namespace %q", serviceName, t.namespace)
+		})
+	return err
 }
 
 func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) error {


### PR DESCRIPTION
## Summary

- Add `waitForWebhookEndpoints()` to spire's `k8sDeployment.Deploy()` to wait for the `spire-controller-manager-webhook` service endpoints before returning

Fixes #52

> Changelog: skip

## Root Cause

PR #52 CI failed with:
```
'Wait for num pods created to match desired count 1.' unsuccessful after 90 retries
```

The `spire-controller-manager` runs as a **sidecar** inside the `spire-server` pod — it has no standalone pod of its own. This means `isPodReady()` cannot detect its readiness. Its admission webhook handles `ClusterSPIFFEID` resources and pod admission for workloads with spire annotations.

When `Deploy()` returns immediately after all spire pods are ready, the webhook endpoints may not yet have any ready addresses. Subsequent pod creation (e.g. `testserver`, `democlient`) is then rejected by the webhook admission controller, causing the "num pods created" retry loop to exhaust its 90 attempts.

## What Changed

In `test/framework/deployments/spire/kubernetes.go`:
- Changed `return nil` at the end of `Deploy()` to `return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")`
- Added `waitForWebhookEndpoints()` which polls the named `Endpoints` object until at least one ready address is present, using the same `DefaultRetries*3` / `DefaultTimeout` pattern already used for pod readiness

## Why the Fix Is Stable

The `spire-controller-manager-webhook` Endpoints object is populated by the endpoint controller once the sidecar's readiness probe passes. Polling it with `retry.DoWithRetryE` ensures `Deploy()` only returns after the webhook is actually usable — preventing the race where workload pods are submitted before the webhook can admit them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)