### PR TITLE
docs(kds): explain IPv4 loopback and backoff reduction in full_sync_test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -63,6 +63,9 @@ var _ = Describe("Full sync tests", func() {
 		cfg.Multizone.Global.KDS.TlsEnabled = false
 		cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 		cfg.Mode = config_core.Global
+		// Reduce backoff from the 5s default: a single "connection refused" hit
+		// on the global gRPC port during zone CP startup would otherwise consume
+		// the entire 30s Eventually window before the zone could reconnect.
 		cfg.General.ResilientComponentBaseBackoff = config_types.Duration{Duration: 100 * time.Millisecond}
 		cfg.General.ResilientComponentMaxBackoff = config_types.Duration{Duration: 5 * time.Second}
 		rt := setup.NewTestRuntime(ctx, cfg, globalStore)
@@ -94,6 +97,9 @@ var _ = Describe("Full sync tests", func() {
 			cfg.Store.Type = config_store.MemoryStore
 			cfg.Mode = config_core.Zone
 			cfg.Multizone.Zone.Name = zoneName
+			// Use 127.0.0.1 (not "localhost"): on Linux CI, "localhost" can
+			// resolve to ::1 (IPv6) while the gRPC server only binds on 0.0.0.0
+			// (IPv4), causing "connection refused" even after the server is ready.
 			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
 			cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 			cfg.General.ResilientComponentBaseBackoff = config_types.Duration{Duration: 100 * time.Millisecond}


### PR DESCRIPTION
## Summary

- Add comment before `ResilientComponentBaseBackoff` explaining why it's reduced from the 5s default to 100ms
- Add comment before `cfg.Multizone.Zone.GlobalAddress` explaining why `127.0.0.1` must be used instead of `localhost`

Closes #33

## Root Cause

The `Full sync tests` in `pkg/kds/context/full_sync_test.go` were flaky due to two interacting issues:

1. **Startup race**: Zone CPs dialed the global CP before `net.Listen` was called. "Connection refused" triggered the resilient component's **5s default base backoff**, consuming most of the 30s `Eventually` window.

2. **IPv6 resolution**: `localhost` on Linux CI can resolve to `::1` (IPv6) while the gRPC server only binds on `0.0.0.0` (IPv4), causing "connection refused" even after the server was ready.

## What Changed

Added two explanatory comments to `full_sync_test.go` at the non-obvious configuration sites:

1. Before `ResilientComponentBaseBackoff`: documents that the 5s default would consume the 30s `Eventually` window on a single failed retry, so it's reduced to 100ms as defense-in-depth.
2. Before `cfg.Multizone.Zone.GlobalAddress`: documents that `127.0.0.1` must be used (not `localhost`) to avoid IPv6 resolution issues on Linux CI runners.

The functional fixes (the `Eventually` port-readiness check, `127.0.0.1` usage, backoff reduction, goroutine cleanup) were already landed in prior commits. This PR makes the intent explicit for future maintainers.

## Why the Fix Is Stable

Documentation-only change — no behavior is altered. The comments prevent future regressions by explaining the constraints at each site.

## Test plan
- [ ] `make format && make check` passes
- [ ] `make test TEST_PKG_LIST=./pkg/kds/context/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)