### PR TITLE
fix(e2e): pre-install mise tools before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -90,8 +90,19 @@ E2E_ENV_VARS += PATH=$(CI_TOOLS_BIN_DIR):$$PATH
 test/e2e/list:
 	@echo $(ALL_TESTS)
 
+.PHONY: test/e2e/k8s/start/clusters
+test/e2e/k8s/start/clusters: $(K8SCLUSTERS_START_TARGETS)
+
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	# Ensure all mise tools are installed before starting clusters in parallel.
+	# When clusters start in parallel, each make subprocess re-evaluates mk/dev.mk,
+	# which calls "$(MISE) which golangci-lint" etc. If the tools are not installed,
+	# mise triggers auto-install in both processes simultaneously, causing a symlink
+	# race condition (EEXIST / "File exists"). Running $(MISE) install here first
+	# ensures tools are pre-installed so the parallel subprocesses never trigger auto-install.
+	$(MISE) install
+	$(MAKE) test/e2e/k8s/start/clusters
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

Fixes #34

- **Root cause**: When `make -j2 test/e2e-multizone` runs, the two k3d cluster start targets (`kuma-1`, `kuma-2`) execute as parallel prerequisites of `test/e2e/k8s/start`. Each spawned subprocess re-evaluates `mk/dev.mk` at startup, which calls `$(MISE) which golangci-lint` and other tool lookups. Since `golangci-lint` and `skaffold` are disabled (not pre-installed) in the e2e workflow's `jdx/mise-action` step, mise triggers auto-install in both parallel processes simultaneously. Both then race to create the `golangci-lint/latest` symlink, with the second failing: `EEXIST: File exists`.
- **What changed**: Introduced a `test/e2e/k8s/start/clusters` helper target that holds the parallel prerequisites. The `test/e2e/k8s/start` recipe now runs `$(MISE) install` serially first, then delegates to this helper. This guarantees all tools are pre-installed before any parallel subprocess evaluates the Makefile.
- **Why stable**: `mise install` is idempotent — it's a no-op if tools are already installed. The serial execution of `$(MISE) install` before the parallel cluster starts ensures no subprocess ever triggers mise auto-install when parsing the Makefile. The parallel behavior for cluster startup is preserved via the prerequisites of `test/e2e/k8s/start/clusters`.

## Test plan

- [ ] Verify CI passes on `test/e2e-multizone` target with `v1.31.12-k3s1`
- [ ] Verify no regression: both clusters still start in parallel (kuma-1 and kuma-2 are prerequisites of the helper target, not sequential goals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)