### PR TITLE
fix(e2e): pre-install mise tools before parallel k3d cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MISE) install # pre-install all tools serially to avoid parallel mise symlink race (EEXIST)
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Summary

- Adds `$(MISE) install` as a serial step before parallel cluster starts in `test/e2e/k8s/start`
- Fixes issue #34: mise symlink race condition (EEXIST) during parallel k3d cluster setup

## Root Cause

`test/e2e/k8s/start` used to list `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites. Each spawned `make` subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk:78`. Since `golangci-lint` and `skaffold` are not pre-installed in the e2e workflow (`MISE_DISABLE_TOOLS` only applies to the `jdx/mise-action` step, not the "Run E2E tests" step), mise's auto-install triggered in both parallel processes simultaneously. Both then raced to rebuild runtime symlinks, with the second process failing: `EEXIST: File exists`.

## What Changed

Modified `test/e2e/k8s/start` in `mk/e2e.new.mk` to run `$(MISE) install` as an explicit serial step before invoking `$(MAKE) $(K8SCLUSTERS_START_TARGETS)` in parallel.

## Why This Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely.

## Test plan

- [ ] Verify CI passes on this PR with label `ci/verify-stability`

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)