### PR TITLE
fix(e2e): remove spiffe-oidc-discovery-provider check and increase spire traffic timeout

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",

--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -68,10 +68,6 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spiffe-oidc-discovery-provider")
-	if err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes #32

## Root Cause

Two issues caused the `kubernetes/meshidentity/spire It` test to flake:

1. **`spiffe-oidc-discovery-provider` readiness check** (`test/framework/deployments/spire/kubernetes.go`): `isPodReady` was called with selector `app.kubernetes.io/name=spiffe-oidc-discovery-provider`, but this component is not deployed as a standalone pod in the SPIRE hardened helm chart. `WaitUntilNumPodsCreatedE` always timed out after 90 retries (~4.5 min), causing `BeforeAll` to fail with: _"Wait for num pods created to match desired count 1."_

2. **Traffic check timeout too short** (`test/e2e_env/kubernetes/meshidentity/spire.go`): The `Eventually` block used a 30s timeout with `MustPassRepeatedly(5)`. On loaded CI runners, the full SPIRE mTLS pipeline (pod attestation → SVID issuance → Envoy SDS reconfiguration) can exceed 30s, leaving no time for 5 consecutive successes and causing 503 errors.

## What Changed

- `test/framework/deployments/spire/kubernetes.go`: Removed the `spiffe-oidc-discovery-provider` readiness check. The agent, server, and csi-driver checks are sufficient to ensure SPIRE is ready.
- `test/e2e_env/kubernetes/meshidentity/spire.go`: Increased traffic check `Eventually` timeout from `"30s"` to `"2m"` to give SPIRE enough time for the full attestation cycle on loaded CI runners.

## Why the Fix Is Stable

- The `spiffe-oidc-discovery-provider` pod never exists as a standalone pod — removing the check eliminates a guaranteed ~4.5 min hang followed by failure in `BeforeAll`.
- 2 minutes is generous for SPIRE certificate provisioning; the SVID issuance cycle completes well within this window even on heavily loaded runners.