### PR TITLE
docs(kds): explain IPv4 loopback requirement in GlobalAddress in full_sync_test

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -94,7 +94,10 @@ var _ = Describe("Full sync tests", func() {
 			cfg.Store.Type = config_store.MemoryStore
 			cfg.Mode = config_core.Zone
 			cfg.Multizone.Zone.Name = zoneName
-			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
+			// Use 127.0.0.1 explicitly instead of "localhost" to avoid IPv6 resolution
+		// on Linux CI runners where "localhost" can resolve to [::1] while the gRPC
+		// server binds only on 0.0.0.0 (IPv4), causing "connection refused" errors.
+		cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)
 			cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 			cfg.General.ResilientComponentBaseBackoff = config_types.Duration{Duration: 100 * time.Millisecond}
 			cfg.General.ResilientComponentMaxBackoff = config_types.Duration{Duration: 5 * time.Second}


### PR DESCRIPTION
## Summary

Fixes #33

- Adds an explanatory comment at the `GlobalAddress` configuration line in `pkg/kds/context/full_sync_test.go` explaining why `127.0.0.1` is used instead of `"localhost"`.

## Root Cause

On Linux CI runners, `"localhost"` can resolve to `[::1]` (IPv6) while the gRPC server binds only on `0.0.0.0` (IPv4). This causes zone mux clients to get "connection refused" on their initial dial, triggering a resilient component backoff and eventually causing the 30s `Eventually` window to expire.

The CI log confirmed this clearly:
```
dial tcp [::1]:42345: connect: connection refused
```

## What Changed

Added a 3-line comment above `cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://127.0.0.1:%d", globalPort)` explaining the IPv4/IPv6 disambiguation. The functional fix (`127.0.0.1` instead of `localhost`) was already applied in commit `8b97f6895`; this PR adds the documentation to prevent future regressions from "helpfully" reverting to `localhost`.

## Why This Fix Is Stable

The comment makes the intent explicit, so reviewers and future contributors won't accidentally change `127.0.0.1` back to `localhost` without understanding why. The underlying fix itself (using `127.0.0.1`) has been in place since `8b97f6895` and is proven stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)