### PR TITLE
fix(kds): make storeStreamConnection sleep context-aware to speed up test teardown

### DIFF
--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -278,7 +278,11 @@ func (g *KDSSyncServiceServer) storeStreamConnection(ctx context.Context, zone s
 	// In this case, all instances will try to update Zone Insight which will result in conflicts.
 	// Since it's unusual to immediately execute envoy admin rpcs after zone is connected, 0-10s delay should be fine.
 	// #nosec G404 - math rand is enough
-	time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
+	select {
+	case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	zoneInsight := system.NewZoneInsightResource()
 	return core_manager.Upsert(ctx, g.resManager, key, zoneInsight, func(resource core_model.Resource) error {

--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -269,7 +269,11 @@ func (g *GlobalKDSServiceServer) storeStreamConnection(ctx context.Context, zone
 	// In this case, all instances will try to update Zone Insight which will result in conflicts.
 	// Since it's unusual to immediately execute envoy admin rpcs after zone is connected, 0-10s delay should be fine.
 	// #nosec G404 - math rand is enough
-	time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
+	select {
+	case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	zoneInsight := system.NewZoneInsightResource()
 	return manager.Upsert(ctx, g.resManager, key, zoneInsight, func(resource model.Resource) error {


### PR DESCRIPTION
## Root Cause

The `storeStreamConnection` function in both `pkg/kds/mux/zone_sync.go` and `pkg/kds/service/server.go` contains an unconditional `time.Sleep(0–10s)` jitter that delays ZoneInsight upserts on a load-balanced Global CP:

```go
// #nosec G404 - math rand is enough
time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
```

When the `full_sync_test` closes the `done` channel to stop all CPs, gRPC's `GracefulStop()` waits for all active stream handlers to return. Any handler blocked mid-sleep held up `wg.Wait()` for up to 10 extra seconds per zone. Under race-detector load on CI, this extended the effective test duration and widened the window for timing-sensitive flakes.

## What Changed

**`pkg/kds/mux/zone_sync.go`** and **`pkg/kds/service/server.go`**: replaced the unconditional sleep with a context-aware `select`:

```go
select {
case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
case <-ctx.Done():
    return ctx.Err()
}
```

When the stream context is cancelled (zone CP disconnects or test shuts down), the sleep exits immediately and returns `ctx.Err()`. Both call sites already handle `context.Canceled` by returning `codes.Canceled` — the correct graceful-shutdown path — so there is no behaviour change in production.

## Why the Fix Is Stable

- In normal operation the sleep runs to completion as before — only cancellation path is affected
- Stream handlers now exit promptly on cancellation, so `GracefulStop()` returns quickly and `wg.Wait()` no longer blocks for up to 10s per zone
- Callers already handle `context.Canceled` → `codes.Canceled`, so the error propagation is correct
- Combined with the prior fixes (port-readiness `Eventually`, `127.0.0.1` loopback, 100ms backoff), test teardown is now deterministic

Fixes #33