### PR TITLE
fix(e2e): pre-install mise tools in test/e2e/debug before parallel cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -107,6 +107,7 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.


### PR DESCRIPTION
## Summary

- Applies the same `$(MISE) install` pre-install guard to `test/e2e/debug` that was added to `test/e2e/k8s/start` in #103
- Prevents the mise symlink race condition (EEXIST) during parallel k3d cluster setup when using the debug target

## Root Cause

Same race condition as described in #34: `test/e2e/debug` runs `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images`, starting cluster-1 and cluster-2 in parallel. Each spawned make subprocess parses the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`. If golangci-lint is not pre-installed, mise's auto-install triggers in both parallel processes simultaneously. Both then race to rebuild runtime symlinks, with the second process failing: `EEXIST: File exists`.

## What Changed

Added `$(MISE) install` as a serial step before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` in `test/e2e/debug`, consistent with the fix already applied to `test/e2e/k8s/start`.

## Why This Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely.

Fixes #34