### PR TITLE
fix(e2e): pre-install mise tools in test/e2e/debug before parallel cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -107,6 +107,7 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.


### PR DESCRIPTION
## Summary

- The `test/e2e/debug` target uses `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` to start kuma-1 and kuma-2 in parallel
- Each spawned make subprocess parses the full Makefile, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`
- If tools are not pre-installed, mise auto-install triggers in both parallel processes simultaneously, then both race to rebuild runtime symlinks → `EEXIST: File exists`
- The same fix was already applied to `test/e2e/k8s/start` (commit 98f26106b); this applies the same pattern to `test/e2e/debug`

## Root Cause

Same race condition as issue #34: parallel `make` subprocesses trigger concurrent mise tool installation, causing a symlink rebuild race (`EEXIST: File exists`).

## What Changed

Added `$(MISE) install` as a serial step before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` in `test/e2e/debug` (`mk/e2e.new.mk`).

## Why This Is Stable

`mise install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so neither subprocess triggers mise auto-install when parsing the Makefile. This eliminates the race condition entirely.

Fixes #34