### PR TITLE
fix(e2e): delete ClusterSPIFFEID in E2EAfterAll to prevent resource leaks

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -67,6 +67,7 @@ spec:
 	})
 
 	E2EAfterAll(func() {
+		Expect(DeleteYamlK8s(workflowRegistration)(kubernetes.Cluster)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(spireNamespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())


### PR DESCRIPTION
Fixes #32

## Summary

- Added `DeleteYamlK8s(workflowRegistration)(kubernetes.Cluster)` as the first step in `E2EAfterAll` in `test/e2e_env/kubernetes/meshidentity/spire.go`

## Root Cause

`ClusterSPIFFEID` is a cluster-scoped Kubernetes resource. The `E2EAfterAll` hook only deleted the namespaces (`meshidentity-spire` and `spire-system`) and the mesh, but never explicitly removed the `ClusterSPIFFEID` named `spire-registration`. Since cluster-scoped resources have no namespace owner, namespace deletion leaves the `ClusterSPIFFEID` behind. On subsequent test runs (re-runs or parallel jobs on the same cluster), the leftover `ClusterSPIFFEID` can conflict with the one the test tries to create in `BeforeAll`, causing the setup to fail.

## What Changed

Added cleanup of the `ClusterSPIFFEID` resource before namespace teardown in `E2EAfterAll`.

## Why the Fix Is Stable

`DeleteYamlK8s` uses the exact same YAML that was used to create the resource, ensuring precise deletion. Deleting it before namespaces ensures any finalizers are resolved in the correct order. This prevents resource accumulation between test runs.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)