### PR TITLE
fix(e2e): pre-install mise tools in test/e2e/debug before parallel cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -107,6 +107,7 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.


### PR DESCRIPTION
## Summary

- Adds `$(MISE) install` as a serial step before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` in `test/e2e/debug`
- Applies the same pattern already used in `test/e2e/k8s/start` (commit 98f26106b)
- Fixes #34

## Root Cause

`test/e2e/debug` runs `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) in parallel via `$(MAKE) -j`. Each spawned make subprocess parses the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk:78`.

Since `golangci-lint` and `skaffold` are excluded by `MISE_DISABLE_TOOLS` in the e2e workflow's `jdx/mise-action` step, those tools are not pre-installed. When both parallel subprocesses evaluate `$(MISE) which golangci-lint)`, mise auto-install triggers in both simultaneously. Both then race to rebuild runtime symlinks, with the second process failing:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
```

## What Changed

Added `$(MISE) install` as a serial step before the parallel cluster start in `test/e2e/debug`. This pre-installs all tools before any subprocess parses the Makefile.

## Why This Is Stable

`mise install` is idempotent — it is a no-op if all tools are already installed. Running it once serially ensures all tools are available before any parallel subprocess parses the Makefile, eliminating the race condition entirely.