### PR TITLE
fix(e2e): document mise race condition in test/e2e/k8s/start

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,6 +91,17 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
+# IMPORTANT: $(MISE) install MUST run serially before the parallel cluster starts below.
+# The CI workflow uses MISE_DISABLE_TOOLS=golangci-lint,skaffold in the jdx/mise-action
+# step, so those tools are not pre-installed. When $(MAKE) -j spawns parallel subprocesses
+# for kuma-1 and kuma-2, each subprocess re-parses mk/dev.mk at startup and evaluates
+# $(shell $(MISE) which golangci-lint) and similar expressions. If any tool is missing,
+# mise auto-install triggers in both subprocesses simultaneously. Both then race to
+# rebuild runtime symlinks (e.g. create skaffold/latest), and the second process fails:
+#   mise ERROR failed to ln -sf ./2.18.0 skaffold/latest
+#   mise ERROR File exists (os error 17)
+# Running $(MISE) install once before the parallel starts ensures all tools and their
+# symlinks exist. $(MISE) install is idempotent (no-op if already installed).
 test/e2e/k8s/start:
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)


### PR DESCRIPTION
## Summary

Fixes flaky test from issue #16 (`sidecarContainers` E2E job).

- Added a detailed comment to `test/e2e/k8s/start` in `mk/e2e.new.mk` explaining why `$(MISE) install` must run before the parallel cluster starts

## Root Cause

The CI workflow uses `MISE_DISABLE_TOOLS=golangci-lint,skaffold` in the `jdx/mise-action` setup step, so those tools are not pre-installed. When `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` spawns parallel subprocesses for kuma-1 and kuma-2, each subprocess re-parses `mk/dev.mk` at startup and evaluates `$(shell $(MISE) which golangci-lint)` and similar expressions. If any tool is missing, mise auto-install triggers in both subprocesses simultaneously. Both then race to rebuild runtime symlinks (e.g. create `skaffold/latest`), and the second process fails:

```
mise ERROR failed to ln -sf ./2.18.0 skaffold/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## What Was Changed

Added an explanatory comment to `test/e2e/k8s/start` in `mk/e2e.new.mk` documenting the race condition. The `$(MISE) install` guard before `$(MAKE) -j` was already added in prior commits (98f26106b and 006d85c55) to fix this race, but without documentation it risks being removed or reordered in future refactoring.

## Why the Fix Is Stable

`$(MISE) install` is idempotent — it's a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools and their runtime symlinks are created. Neither subprocess then triggers mise auto-install when evaluating `$(shell $(MISE) which ...)` expressions. The comment makes this invariant explicit for future maintainers.