### PR TITLE
fix(e2e): wait for spire-controller-manager webhook endpoints before returning from Deploy

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -1,8 +1,12 @@
 package spire
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -69,7 +73,37 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
-	return nil
+	// The spire-controller-manager runs as a sidecar inside the spire-server pod,
+	// so isPodReady cannot detect its readiness. Its admission webhook handles
+	// ClusterSPIFFEID resources. Wait until the webhook service has ready endpoints
+	// before returning, otherwise applying ClusterSPIFFEID immediately after Deploy()
+	// may fail because the webhook is not yet accepting connections.
+	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
+}
+
+// waitForWebhookEndpoints polls the named Endpoints object until it has at least
+// one ready address.
+func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, serviceName string) error {
+	clientset, err := k8s.GetKubernetesClientFromOptionsE(cluster.GetTesting(), cluster.GetKubectlOptions(t.namespace))
+	if err != nil {
+		return err
+	}
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for webhook endpoints %s", serviceName),
+		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultTimeout,
+		func() (string, error) {
+			ep, err := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			for _, subset := range ep.Subsets {
+				if len(subset.Addresses) > 0 {
+					return "ready", nil
+				}
+			}
+			return "", errors.Errorf("no ready endpoints for service %q in namespace %q", serviceName, t.namespace)
+		})
+	return err
 }
 
 func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) error {


### PR DESCRIPTION
## Summary

- Add `waitForWebhookEndpoints()` to spire's `k8sDeployment.Deploy()` to wait for the `spire-controller-manager-webhook` service endpoints before returning

Fixes #16

> Changelog: skip

## Root Cause

The CI annotation for the flaky test pointed to `test/e2e_env/kubernetes/meshidentity/spire.go#58` — the `Expect(err).ToNot(HaveOccurred())` line in `BeforeAll` where the cluster setup assertion failed.

The `BeforeAll` installs spire via helm, waits for pod readiness, then applies a `ClusterSPIFFEID` resource. The `spire-controller-manager` runs as a **sidecar** inside the `spire-server` pod — it has no standalone pod of its own. This means `isPodReady()` cannot detect its readiness.

After all spire pods are marked ready, the admission webhook for `ClusterSPIFFEID` resources may not yet have any ready endpoint addresses. The subsequent `Install(YamlK8s(workflowRegistration))` call to apply the `ClusterSPIFFEID` is then rejected by the admission controller, causing `BeforeAll` to fail:

```
Error from server (ServiceUnavailable): error when creating "...": ... connect: connection refused
```

## What Changed

In `test/framework/deployments/spire/kubernetes.go`:
- Changed `return nil` at the end of `Deploy()` to `return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")`
- Added `waitForWebhookEndpoints()` which polls the named `Endpoints` object until at least one ready address is present, using the same `DefaultRetries*3` / `DefaultTimeout` pattern already used for pod readiness

## Why the Fix Is Stable

The `spire-controller-manager-webhook` Endpoints object is populated by the endpoint controller once the sidecar's readiness probe passes. Polling it with `retry.DoWithRetryE` ensures `Deploy()` only returns after the webhook is actually usable — eliminating the race where `ClusterSPIFFEID` is applied before the webhook can admit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)