### PR TITLE
fix(e2e): pre-install mise tools in test/e2e/debug before parallel starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -107,6 +107,7 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.


### PR DESCRIPTION
## Summary

- Adds `$(MISE) install` as a serial step before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images` in `test/e2e/debug`
- Matches the pattern already applied to `test/e2e/k8s/start` in commits `98f26106b` and `006d85c55`
- Fixes #34

## Root Cause

`test/e2e/debug` ran `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images` without pre-installing mise tools. Each parallel `make` subprocess evaluates `$(shell $(MISE) which golangci-lint)` at parse time via `mk/dev.mk`. Since `golangci-lint` and `skaffold` are excluded by `MISE_DISABLE_TOOLS` in the e2e workflow, mise auto-install triggered in both parallel subprocesses simultaneously. Both raced to rebuild the symlink at `~/.local/share/mise/installs/golangci-lint/latest`, with the second failing:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## What Changed

Added `$(MISE) install` as a serial step at the top of `test/e2e/debug`, before the parallel `$(MAKE) -j` invocation.

## Why This Is Stable

`mise install` is idempotent — it is a no-op when all tools are already installed. Running it once serially before any parallel cluster starts ensures all tools are pre-installed with their symlinks fully created before any subprocess parses the Makefile, eliminating the symlink creation race entirely.

## Test plan

- [ ] CI passes with `ci/verify-stability` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)