### PR TITLE
fix(e2e): fix MustPassRepeatedly positional arg and g.Expect in spire tests

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "2m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",

--- a/test/e2e_env/universal/meshidentity/spire.go
+++ b/test/e2e_env/universal/meshidentity/spire.go
@@ -173,8 +173,8 @@ spec:
 
 		Eventually(func(g Gomega) {
 			s, err := admin.GetStats("listener.*_80.ssl.handshake")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s).To(stats.BeGreaterThanZero())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeGreaterThanZero())
 		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
Fixes #32

## Summary

- Fixed `MustPassRepeatedly(5)` positional argument bug in `test/e2e_env/kubernetes/meshidentity/spire.go`
- Fixed bare `Expect` inside `Eventually(func(g Gomega))` in `test/e2e_env/universal/meshidentity/spire.go`

## Root Cause

**Bug 1 — kubernetes/spire.go** (`MustPassRepeatedly` positional arg):

`MustPassRepeatedly(5)` was passed as a 4th positional argument to `Eventually`:
```go
// Before (broken — "2m" timeout ignored, uses 30s default)
}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
```
When `MustPassRepeatedly` is a positional arg, Gomega ignores the explicit `"2m"` timeout and uses the default (30s set by `SetDefaultEventuallyTimeout`). The test was effectively running with a 30s window to establish SPIRE mTLS traffic 5 consecutive times — insufficient for SPIRE certificate issuance and Envoy SDS propagation on loaded CI runners.

**Bug 2 — universal/spire.go** (bare `Expect` inside `Eventually(func(g Gomega))`):

The final `Eventually` block checking `ssl.handshake` stats used the outer `Expect` instead of the inner `g.Expect`:
```go
// Before (broken — fatal failure on first attempt, no retry)
Eventually(func(g Gomega) {
    s, err := admin.GetStats("listener.*_80.ssl.handshake")
    Expect(err).ToNot(HaveOccurred())
    Expect(s).To(stats.BeGreaterThanZero())
}, "30s", "1s").Should(Succeed())
```
Using the outer `Expect` inside `Eventually(func(g Gomega))` causes an immediate fatal failure on the first attempt rather than allowing `Eventually` to retry. If SPIRE SVIDs haven't fully propagated when the check first runs, the test fails immediately.

## What Changed

- `test/e2e_env/kubernetes/meshidentity/spire.go`: Changed positional `MustPassRepeatedly(5)` to method chain: `}.MustPassRepeatedly(5).Should(Succeed())`
- `test/e2e_env/universal/meshidentity/spire.go`: Changed `Expect(err)` → `g.Expect(err)` and `Expect(s)` → `g.Expect(s)` inside `Eventually(func(g Gomega))`

## Why the Fix Is Stable

- The method chain form is the correct Gomega API: `Eventually(..., "2m", "1s").MustPassRepeatedly(5).Should(Succeed())` applies the 2m timeout as intended, giving SPIRE sufficient time to issue certificates and establish mTLS traffic reliably.
- Using `g.Expect` inside `Eventually(func(g Gomega))` is the required pattern per Gomega docs — failures are treated as retry signals, not fatal errors, allowing `Eventually` to retry as designed.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)