### PR TITLE
fix(e2e): wait for spire-controller-manager pod readiness before returning from Deploy

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -68,6 +68,10 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
+	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `isPodReady` check for `spire-controller-manager` at the end of the `Deploy` method in `test/framework/deployments/spire/kubernetes.go`
- Matches the existing pattern used for agent, server, and spiffe-csi-driver components

## Root Cause

`Deploy` returned after waiting for agent/server/spiffe-csi-driver but **not** `spire-controller-manager`. The controller manager hosts the `vclusterspiffeid.kb.io` admission webhook. When `BeforeAll` applied a `ClusterSPIFFEID` immediately after `Deploy` returned, the webhook endpoints were not yet available, causing intermittent admission failures:

```
BeforeAll 03/19/26 22:23:47.03
```

## Fix

Added `t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` using the same `isPodReady` helper with the existing `DefaultRetries*3` timeout, matching the pattern for the other SPIRE components. This ensures the admission webhook is ready before any `ClusterSPIFFEID` resources are applied.

## Stability

The fix is deterministic — it adds a synchronous readiness gate that blocks until the webhook is fully available, eliminating the race window. No timing assumptions remain.

Fixes #31

> Changelog: skip