### PR TITLE
fix(e2e): pre-install mise tools in test/e2e/debug before parallel cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -107,6 +107,11 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	# Pre-install all mise tools serially before the parallel cluster starts below.
+	# Without this, two parallel make subprocesses evaluating $(shell $(MISE) which ...)
+	# in mk/dev.mk can simultaneously trigger mise auto-install and race to create
+	# runtime symlinks, failing with: "File exists (os error 17)".
+	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.


### PR DESCRIPTION
## Summary

Fixes flaky test from issue #16 (`sidecarContainers, v1.34.1-k3s1, kubernetes` E2E job).

- Added `$(MISE) install` as a serial step in `test/e2e/debug` before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` to match the protection already in `test/e2e/k8s/start`

## Root Cause

**Confirmed from CI run logs** (run 23249787080, job 67620726437):

```
KIND_CLUSTER_NAME=kuma-1 make k3d/start
KIND_CLUSTER_NAME=kuma-2 make k3d/start
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
make: *** [mk/e2e.new.mk:135: test/e2e-kubernetes] Error 2
```

At the time of the failure, `K3D_BIN` was defined as `$(MISE) exec -- k3d`. The `mise exec` command installs ALL tools from `mise.toml` before running k3d — including golangci-lint and skaffold, which were excluded from the initial `jdx/mise-action` setup via `MISE_DISABLE_TOOLS`. When two parallel make subprocesses (kuma-1 and kuma-2) both ran `mise exec -- k3d cluster create` simultaneously, both triggered installation of skaffold/golangci-lint and raced to create the runtime symlink.

Two fixes were applied to master after the failure:
1. **`957ec4ee7`**: Changed `K3D_BIN` from `$(MISE) exec -- k3d` to `$(shell $(MISE) which k3d)`, eliminating the full-tool-install trigger
2. **`98f26106b` + `006d85c55`**: Added `$(MISE) install` to `test/e2e/k8s/start` before the parallel cluster starts

`test/e2e/debug` has the same parallel cluster start pattern but was missing the `$(MISE) install` guard.

## What Was Changed

Added `$(MISE) install` to `test/e2e/debug` in `mk/e2e.new.mk` before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)`, with a comment explaining the race condition.

## Why the Fix Is Stable

`$(MISE) install` is idempotent — it is a no-op if all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools and their runtime symlinks are created before any parallel subprocess is spawned. This matches the pattern already in `test/e2e/k8s/start` (the CI target) and closes the same gap for the local debug workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)