### PR TITLE
fix(e2e): pre-install mise tools before parallel k8s cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,7 +91,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MISE) install
+	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop


### PR DESCRIPTION
## Root Cause

When `make -j2` runs `test/e2e-multizone` or `test/e2e-kubernetes`, the `-j2` flag is passed via `MAKEFLAGS` to all sub-make processes. The `test/e2e/k8s/start` target listed `K8SCLUSTERS_START_TARGETS` as **make prerequisites**, which caused make to start kuma-1 and kuma-2 cluster setups in parallel.

Each parallel subprocess parses the full Makefile at startup, evaluating expressions like `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`. Since `MISE_DISABLE_TOOLS` in the `jdx/mise-action` step only covers that specific step, golangci-lint and skaffold are not pre-installed when the e2e step begins. Both parallel subprocesses therefore trigger mise auto-install concurrently, and both race to create the runtime symlink:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
```

This causes one of the cluster start subprocesses to fail, aborting the entire test run.

## Fix

Run `$(MISE) install` as a single **serial** step before launching parallel cluster starts with `$(MAKE) -j`. The mise install is idempotent — it is a no-op when all tools are already installed — so it adds negligible overhead on subsequent runs. This ensures all tool symlinks are in place before any parallel subprocess evaluates Makefile variables, eliminating the race entirely.

## Why It's Stable

- `mise install` with all tools already installed completes in milliseconds
- The fix is deterministic: there is no window for a race because tools are fully installed before any parallel process starts
- Pattern already validated in `test/e2e/debug` target (same approach)

Closes #114

> Changelog: skip