### PR TITLE
docs(e2e): document mise race condition guard in cluster start targets

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -91,6 +91,13 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
+# NOTE: $(MISE) install must run before the parallel -j cluster starts.
+# Each $(MAKE) k3d/start subprocess re-parses the full Makefile, evaluating
+# $(shell $(MISE) which <tool>) for every tool in mk/dev.mk. If any tool is not
+# yet installed, mise auto-install triggers in both parallel processes simultaneously
+# and they race to create runtime symlinks, failing with EEXIST (os error 17).
+# Running $(MISE) install once serially here ensures all tools are pre-installed
+# so $(MISE) which is a no-op in the parallel subprocesses.
 test/e2e/k8s/start:
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
@@ -107,7 +114,7 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
-	$(MISE) install
+	$(MISE) install # must run before -j cluster starts to prevent mise symlink race (see test/e2e/k8s/start comment)
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.


### PR DESCRIPTION
## Summary

- Adds inline comment block to `test/e2e/k8s/start` explaining why `$(MISE) install` must precede the parallel `-j $(K8SCLUSTERS_START_TARGETS)` invocation
- Adds inline comment to `test/e2e/debug` cross-referencing the detailed explanation

## Root Cause of Flake (#34)

The `test_e2e_env (v1.31.12-k3s1, multizone, amd64)` CI job failed with:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
```

**Root cause**: When `test/e2e/k8s/start` ran `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)`, each parallel `make k3d/start` subprocess re-parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` (and other tools) via `mk/dev.mk`. Since `golangci-lint` and `skaffold` are excluded by `MISE_DISABLE_TOOLS` in the `jdx/mise-action` workflow step (but NOT in the subsequent "Run E2E tests" step), mise auto-install triggered in both parallel processes simultaneously. Both raced to create the `golangci-lint/latest` symlink, with the second failing with `EEXIST (os error 17)`.

## What Was Changed

The functional fix was already applied in commits `98f26106b` and `006d85c55` (adding `$(MISE) install` before parallel cluster starts in `mk/e2e.new.mk`). This PR adds documentation comments explaining the purpose of those lines, preventing future developers from accidentally removing what appears to be a redundant install step.

## Why the Fix Is Stable

`$(MISE) install` is idempotent — it is a no-op when all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed, so `$(MISE) which` in the parallel subprocesses is a read-only lookup with no symlink creation, eliminating the race entirely.

> Changelog: skip