### PR TITLE
ci(e2e): document why mise install must precede parallel cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -92,6 +92,11 @@ test/e2e/list:
 
 .PHONY: test/e2e/k8s/start
 test/e2e/k8s/start:
+	# $(MISE) install must run serially before parallel cluster starts.
+	# Each $(MAKE) -j subprocess parses the full Makefile at startup,
+	# evaluating $(shell $(MISE) which golangci-lint) etc. in mk/dev.mk.
+	# If tools are not pre-installed, mise auto-install triggers in both
+	# parallel processes simultaneously, causing a symlink race (EEXIST).
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets


### PR DESCRIPTION
## Root cause

The `test / test_e2e_env (v1.31.12-k3s1, multizone, amd64)` job failed at cluster setup because:

1. `test/e2e/k8s/start` used to list `$(K8SCLUSTERS_START_TARGETS)` (kuma-1, kuma-2) as parallel make prerequisites
2. Each spawned `make` subprocess parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`
3. Since `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` only applies to the `jdx/mise-action` step (not the "Run E2E tests" step), these tools were not pre-installed
4. Both parallel processes triggered mise auto-install simultaneously and raced to rebuild runtime symlinks:
   ```
   mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
   mise ERROR File exists (os error 17)
   ```

## What was changed

The `$(MISE) install` serial pre-install step was added before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` in a previous fix (commits `98f26106b` and `006d85c55`). This PR adds explanatory comments to `mk/e2e.new.mk` documenting **why** the serial `$(MISE) install` must precede the parallel cluster starts, preventing future regressions where someone might accidentally remove or reorder this step.

## Why the fix is stable

`$(MISE) install` is idempotent — it is a no-op when all tools are already installed. Running it once serially before parallel cluster starts ensures all tools are pre-installed, so no child subprocess triggers mise auto-install when parsing the Makefile. This eliminates the symlink race condition entirely.

Fixes #34