### PR TITLE
docs(e2e): explain why mise install must precede parallel cluster starts

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -92,6 +92,15 @@ test/e2e/list:
 
 .PHONY: test/e2e/k8s/start
 test/e2e/k8s/start:
+	# IMPORTANT: $(MISE) install MUST run before the parallel -j invocation.
+	# Each parallel make subprocess parses the full Makefile at startup, which
+	# evaluates $(shell $(MISE) which golangci-lint) in mk/dev.mk. If those tools
+	# are not yet installed, mise auto-install triggers in every subprocess
+	# simultaneously, and they race to create the same runtime symlink, causing:
+	#   mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
+	#   mise ERROR File exists (os error 17)
+	# Running mise install once serially here pre-installs all tools so that
+	# subprocess Makefile parsing is a read-only lookup with no symlink creation.
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
@@ -107,6 +116,8 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	# IMPORTANT: $(MISE) install MUST run before the parallel -j invocation.
+	# See the comment in test/e2e/k8s/start for the full explanation.
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag


### PR DESCRIPTION
## Summary

- Adds explanatory comments to `test/e2e/k8s/start` and `test/e2e/debug` in `mk/e2e.new.mk` documenting why `$(MISE) install` must run serially before the parallel `-j` cluster invocation
- The functional fix (`$(MISE) install` lines) was already applied in commits `98f26106b`, `006d85c55`, and `7bd4a5c5d`; this PR documents the reasoning to prevent future regressions

Fixes #34

## Root Cause

When `test/e2e/k8s/start` ran `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` to start kuma-1 and kuma-2 in parallel, each spawned `make` subprocess re-parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`. Since `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` only applied to the `jdx/mise-action` step (not the "Run E2E tests" step), mise auto-install triggered in both parallel subprocesses simultaneously. Both raced to rebuild the runtime symlink:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## Fix

`$(MISE) install` is idempotent — it's a no-op when all tools are already installed. Running it once serially before any parallel cluster starts ensures all tools are pre-installed, so subprocess Makefile parsing is a read-only lookup with no symlink creation.

## Test plan

- [ ] Verify `mk/e2e.new.mk` comments accurately describe the race condition
- [ ] Confirm the `$(MISE) install` pre-step remains in place before all parallel `-j` invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)