### PR TITLE
docs(e2e): document mise race condition guard in test/e2e/k8s/start

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -90,6 +90,14 @@ E2E_ENV_VARS += PATH=$(CI_TOOLS_BIN_DIR):$$PATH
 test/e2e/list:
 	@echo $(ALL_TESTS)
 
+# NOTE: $(MISE) install MUST run serially before the parallel -j cluster starts.
+# When make spawns parallel subprocesses for $(K8SCLUSTERS_START_TARGETS), each
+# subprocess parses the full Makefile and evaluates $(shell $(MISE) which <tool>)
+# expressions in mk/dev.mk. If any tool is not yet installed, mise auto-install
+# triggers in every subprocess simultaneously, and they race to create runtime
+# symlinks (e.g. golangci-lint/latest), causing EEXIST failures. Running
+# $(MISE) install once here ensures all tools are pre-installed before any
+# parallel subprocess starts. mise install is idempotent when tools already exist.
 .PHONY: test/e2e/k8s/start
 test/e2e/k8s/start:
 	$(MISE) install


### PR DESCRIPTION
## Summary

- Adds an explanatory comment to `test/e2e/k8s/start` in `mk/e2e.new.mk` documenting why `$(MISE) install` must run serially before the parallel `-j` cluster starts.
- The functional fix was already applied in commits `98f26106b` and `006d85c55`; this PR only adds the documentation to prevent future regression.

## Root cause of the flake

The `test_e2e_env (v1.31.12-k3s1, multizone, amd64)` job failed because `test/e2e/k8s/start` ran `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` to start `kuma-1` and `kuma-2` in parallel. Each spawned `make k3d/start` subprocess re-parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`. Since `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` only applied to the `jdx/mise-action` step (not the "Run E2E tests" step), mise auto-install triggered in both parallel processes simultaneously. Both raced to rebuild the runtime symlink at `~/.local/share/mise/installs/golangci-lint/latest`, with the second failing:
```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## What was changed

Added 8-line comment block above `.PHONY: test/e2e/k8s/start` explaining:
- Why `$(MISE) install` must precede the parallel `-j` invocation
- The mechanism (Makefile parsing triggers mise auto-install in each subprocess)
- Why the fix is safe (`mise install` is idempotent)

## Why the fix is stable

`$(MISE) install` is idempotent — it is a no-op when all tools are already installed. Running it once serially before any parallel cluster starts ensures all tools are pre-installed with their symlinks fully created, so no child subprocess triggers mise auto-install when parsing the Makefile. The comment documents this invariant so it is not accidentally removed.

Fixes #34

> Changelog: skip