### PR TITLE
fix(kds): make storeStreamConnection sleep context-aware

### DIFF
--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -278,7 +278,11 @@ func (g *KDSSyncServiceServer) storeStreamConnection(ctx context.Context, zone s
 	// In this case, all instances will try to update Zone Insight which will result in conflicts.
 	// Since it's unusual to immediately execute envoy admin rpcs after zone is connected, 0-10s delay should be fine.
 	// #nosec G404 - math rand is enough
-	time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
+	select {
+	case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	zoneInsight := system.NewZoneInsightResource()
 	return core_manager.Upsert(ctx, g.resManager, key, zoneInsight, func(resource core_model.Resource) error {

--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -269,7 +269,11 @@ func (g *GlobalKDSServiceServer) storeStreamConnection(ctx context.Context, zone
 	// In this case, all instances will try to update Zone Insight which will result in conflicts.
 	// Since it's unusual to immediately execute envoy admin rpcs after zone is connected, 0-10s delay should be fine.
 	// #nosec G404 - math rand is enough
-	time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
+	select {
+	case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	zoneInsight := system.NewZoneInsightResource()
 	return manager.Upsert(ctx, g.resManager, key, zoneInsight, func(resource model.Resource) error {


### PR DESCRIPTION
## Root Cause

`storeStreamConnection` in `pkg/kds/mux/zone_sync.go` and `pkg/kds/service/server.go` contains an unconditional `time.Sleep(0–10s)` jitter:

```go
// #nosec G404 - math rand is enough
time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
```

When the `full_sync_test` closes the `done` channel to stop all CPs, gRPC's `GracefulStop()` waits for all active stream handlers to return. Any handler blocked mid-sleep holds up `wg.Wait()` for up to 10 extra seconds per zone. Under load on CI, this extended the effective test duration and widened the window for the timing-sensitive flake in `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled`.

## What Changed

Replaced the unconditional `time.Sleep` with a context-aware `select` in both files:

```go
select {
case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
case <-ctx.Done():
    return ctx.Err()
}
```

When the stream context is cancelled (zone CP disconnects or test shuts down), the sleep exits immediately and returns `ctx.Err()`. Both call sites already handle `context.Canceled` by returning `codes.Canceled` — the correct graceful-shutdown path — so there is no behaviour change in production.

## Why the Fix Is Stable

- Test teardown no longer blocks for up to 10s per zone on shutdown
- The jitter delay still applies in production when the context is live, preserving the load-balancer conflict-avoidance behaviour
- Both call sites handle `context.Canceled` correctly already

Fixes #33