### PR TITLE
fix(e2e): wait for spire-controller-manager pod before returning from Deploy

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -68,6 +68,10 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
+	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Root Cause

The `sidecarContainers` E2E job runs `test/e2e_env/kubernetes/meshidentity/spire.go`. In `BeforeAll`, SPIRE is installed via helm, then a `ClusterSPIFFEID` resource (`workflowRegistration`) is applied immediately after.

`Deploy()` waited for `agent`, `server`, and `spiffe-csi-driver` pods to be ready, but **not** `spire-controller-manager`. The controller manager hosts the `vclusterspiffeid.kb.io` admission webhook. When `BeforeAll` applied the `ClusterSPIFFEID` while webhook endpoints were still empty, the admission controller rejected it with:

```
failed calling webhook "vclusterspiffeid.kb.io": no endpoints available for service "spire-controller-manager-webhook"
```

This caused multiple retries in `BeforeAll`, and in slow CI environments the cascading delay left the `It` block with insufficient time budget, causing the `Eventually` to time out.

## Fix

Added `t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` in `test/framework/deployments/spire/kubernetes.go`, using the same `isPodReady` helper with `DefaultRetries*3` timeout already used for the other SPIRE components. This ensures the admission webhook is ready before any `ClusterSPIFFEID` resources are applied.

## Why This Is Stable

The fix is deterministic — it adds a synchronous readiness gate that blocks until `spire-controller-manager` is fully available, eliminating the race between `Deploy()` completing and the webhook being ready to accept `ClusterSPIFFEID` resources.

Fixes #32

> Changelog: skip