### PR TITLE
docs(e2e): explain mise race condition guard in test/e2e/k8s/start

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -92,6 +92,15 @@ test/e2e/list:
 
 .PHONY: test/e2e/k8s/start
 test/e2e/k8s/start:
+	# $(MISE) install MUST run serially before the parallel -j invocation below.
+	# Each sub-make spawned by -j re-parses the full Makefile, which evaluates
+	# $(shell $(MISE) which <tool>) expressions in mk/dev.mk. If a tool is not
+	# yet installed, mise auto-installs it and races to create the runtime
+	# symlink (e.g. golangci-lint/latest). The second parallel process fails:
+	#   mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
+	#   mise ERROR File exists (os error 17)
+	# Running $(MISE) install first is idempotent and ensures all symlinks exist
+	# before any parallel subprocess parses the Makefile.
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets


### PR DESCRIPTION
## Summary

- Adds an explanatory comment to `test/e2e/k8s/start` in `mk/e2e.new.mk` documenting why `$(MISE) install` must run serially before the parallel `-j` cluster start invocation.
- Without this comment, the critical ordering constraint is not obvious and risks being accidentally removed in a future refactor.

## Root cause of the flake

The `test_e2e_env (v1.31.12-k3s1, multizone, amd64)` job failed because `test/e2e/k8s/start` ran `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` to start `kuma-1` and `kuma-2` in parallel. Each spawned `make k3d/start` subprocess re-parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`. Since `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` only applied to the `jdx/mise-action` step (not the "Run E2E tests" step), mise auto-install triggered in both parallel processes simultaneously. Both raced to rebuild the runtime symlink at `~/.local/share/mise/installs/golangci-lint/latest`, with the second failing:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## What was changed

The functional fix was already applied in commits `98f26106b`, `006d85c55`, and `7bd4a5c5d` (adding `$(MISE) install` before parallel cluster starts). This PR adds a comment explaining **why** `$(MISE) install` must precede the parallel `-j` invocation, preventing future developers from accidentally removing this critical ordering.

## Why the fix is stable

`$(MISE) install` is idempotent — it is a no-op when all tools are already installed. Running it once serially before the parallel cluster starts ensures all tools are pre-installed with their symlinks fully created, so no child subprocess triggers mise auto-install when parsing the Makefile. This eliminates the symlink race condition entirely.

Fixes #34

> Changelog: skip