### PR TITLE
fix(e2e): wait for spire-controller-manager webhook endpoints before returning from Deploy

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -1,8 +1,12 @@
 package spire
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -69,7 +73,33 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
-	return nil
+	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
+}
+
+func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, endpointName string) error {
+	clientset, err := k8s.GetKubernetesClientFromOptionsE(cluster.GetTesting(), cluster.GetKubectlOptions(t.namespace))
+	if err != nil {
+		return errors.Wrap(err, "error getting kubernetes client")
+	}
+
+	_, err = retry.DoWithRetryE(cluster.GetTesting(),
+		fmt.Sprintf("wait for webhook endpoints %s to have ready addresses", endpointName),
+		framework.DefaultRetries*3,
+		framework.DefaultTimeout,
+		func() (string, error) {
+			ep, err := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), endpointName, metav1.GetOptions{})
+			if err != nil {
+				return "", errors.Wrapf(err, "failed to get endpoints %s", endpointName)
+			}
+			for _, subset := range ep.Subsets {
+				if len(subset.Addresses) > 0 {
+					return "webhook endpoint ready", nil
+				}
+			}
+			return "", fmt.Errorf("webhook endpoint %s has no ready addresses yet", endpointName)
+		},
+	)
+	return err
 }
 
 func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) error {


### PR DESCRIPTION
## Root Cause

The `sidecarContainers` E2E job runs the spire mesh identity test (`test/e2e_env/kubernetes/meshidentity/spire.go`). In `BeforeAll`, spire is installed via helm, followed immediately by applying a `ClusterSPIFFEID` resource.

The `spire-controller-manager` runs as a **sidecar** inside the `spire-server` pod. After all spire pods are marked ready, the `spire-controller-manager-webhook` Endpoints object may still have no addresses — the Kubernetes endpoint controller only populates it after the sidecar's readiness probe passes and the endpoint slice controller syncs. Applying the `ClusterSPIFFEID` resource during this window causes the webhook admission controller to reject it, failing `BeforeAll` at `spire.go:58`.

## What Changed

In `test/framework/deployments/spire/kubernetes.go`:
- Added `waitForWebhookEndpoints()` method that polls the named `Endpoints` object until at least one address is present
- Changed `Deploy()` to call `waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")` instead of returning `nil`
- Uses the existing `DefaultRetries*3` / `DefaultTimeout` pattern already used for pod readiness

## Why This Fix Is Stable

The `Endpoints` object for the webhook is only populated by the Kubernetes endpoint controller after the sidecar container's readiness probe passes. Polling it with `retry.DoWithRetryE` ensures `Deploy()` only returns after the webhook is actually serving — eliminating the race between `Deploy()` completing and the webhook being ready to accept `ClusterSPIFFEID` resources.

Fixes #16