### PR TITLE
docs(e2e): explain mise race condition guard in cluster start targets

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -92,6 +92,15 @@ test/e2e/list:
 
 .PHONY: test/e2e/k8s/start
 test/e2e/k8s/start:
+	# $(MISE) install MUST run serially before the parallel -j invocation below.
+	# Each sub-make spawned by -j re-parses the full Makefile, evaluating
+	# $(shell $(MISE) which <tool>) expressions in mk/dev.mk. If a tool is not
+	# yet installed, mise auto-installs it and races to create the runtime
+	# symlink (e.g. golangci-lint/latest). The second parallel process fails with:
+	#   mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
+	#   mise ERROR File exists (os error 17)
+	# Running $(MISE) install first is idempotent and ensures all symlinks exist
+	# before any parallel subprocess parses the Makefile.
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
@@ -107,6 +116,8 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	# $(MISE) install MUST run serially before the parallel -j invocation below.
+	# See test/e2e/k8s/start for the full explanation of this ordering constraint.
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag


### PR DESCRIPTION
## Summary

- Adds explanatory comments to `test/e2e/k8s/start` and `test/e2e/debug` in `mk/e2e.new.mk` documenting why `$(MISE) install` must run serially before the parallel `-j` cluster start invocations.
- Prevents future regressions where this critical ordering constraint might be accidentally removed.

## Root cause of the flake (issue #34)

The `test_e2e_env (v1.31.12-k3s1, multizone, amd64)` job failed during cluster startup with:

```
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

`test/e2e/k8s/start` ran `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)` (kuma-1 and kuma-2 in parallel). Each spawned sub-make re-parsed the full Makefile at startup, evaluating `$(shell $(MISE) which golangci-lint)` in `mk/dev.mk`. Since golangci-lint was not pre-installed, mise auto-install triggered in both parallel processes simultaneously. Both raced to create the `golangci-lint/latest` runtime symlink — the second failed with `EEXIST`.

## What was changed

The functional fix was already applied in commits `98f26106b`, `006d85c55`, and `7bd4a5c5d` (adding `$(MISE) install` as a serial step before the parallel `-j` invocation). This PR adds comments at both call sites explaining **why** this ordering is required.

## Why the fix is stable

`mise install` is idempotent — it is a no-op when all tools are already installed. Running it once serially before any parallel subprocess starts ensures all runtime symlinks exist before any subprocess parses the Makefile. The race condition is eliminated entirely.

> Changelog: skip