### PR TITLE
fix(e2e): remove spire-controller-manager pod check, rely on webhook endpoints

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -71,11 +71,14 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
-	if err != nil {
-		return err
-	}
 
+	// Wait for the spire-controller-manager webhook Endpoints to have at least one
+	// ready address before returning. The controller-manager may run as a sidecar
+	// inside spire-server-0 or as a standalone pod depending on the helm chart
+	// version. Using the Endpoints object (rather than a pod selector) makes this
+	// robust to both topologies: the endpoint controller only populates addresses
+	// after the container's readiness probe passes, ensuring the webhook is
+	// accepting requests before BeforeAll applies any ClusterSPIFFEID resources.
 	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
 }
 


### PR DESCRIPTION
## Root Cause

The `sidecarContainers` E2E job (`test/e2e_env/kubernetes/meshidentity/spire.go`) failed because `Deploy()` in `test/framework/deployments/spire/kubernetes.go` would return before the `spire-controller-manager-webhook` was ready to accept requests. Applying a `ClusterSPIFFEID` resource immediately after `Deploy()` returned caused:

```
failed calling webhook "vclusterspiffeid.kb.io": no endpoints available for service "spire-controller-manager-webhook"
```

A previous fix added `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` to wait for the controller-manager pod. However, in the SPIRE hardened helm chart the controller-manager may run as a **sidecar container inside `spire-server-0`** rather than as a standalone pod. When no pod matches the selector, `WaitUntilNumPodsCreatedE` blocks for ~270 seconds (90 retries × 3 s) before failing, causing `BeforeAll` to time out.

## What Changed

In `test/framework/deployments/spire/kubernetes.go`:
- Removed the `isPodReady` call for `app.kubernetes.io/name=spire-controller-manager`
- Added an explanatory comment to the `waitForWebhookEndpoints` call

`waitForWebhookEndpoints()` (already present) is topology-agnostic: it polls the `Endpoints` object directly, which the Kubernetes endpoint controller only populates after the container's readiness probe passes. This works regardless of whether the controller-manager is a sidecar or standalone pod.

## Why This Fix Is Stable

The `Endpoints` object is authoritative — no address is added until the container is ready and the endpoint controller has synced. Polling it ensures the webhook is actually serving before `BeforeAll` proceeds, without any assumptions about the pod topology. Removing the fragile pod-selector check eliminates the potential 4.5-minute hang.

Fixes #16