### PR TITLE
fix(e2e): wait for spire webhook service before applying ClusterSPIFFEID

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -69,6 +69,16 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
+	// Wait for the controller-manager webhook service to have endpoints.
+	// The controller-manager runs as a sidecar in the spire-server pod and serves
+	// admission webhooks for ClusterSPIFFEID resources. The pod can be Available
+	// before the webhook server is ready to accept connections.
+	k8s.WaitUntilServiceAvailable(cluster.GetTesting(),
+		cluster.GetKubectlOptions(t.namespace),
+		"spire-controller-manager-webhook",
+		framework.DefaultRetries*3,
+		framework.DefaultTimeout)
+
 	return nil
 }
 


### PR DESCRIPTION
## Root Cause

The `BeforeAll` in `test/e2e_env/kubernetes/meshidentity/spire.go` installs SPIRE via Helm and then immediately applies a `ClusterSPIFFEID` resource. The `ClusterSPIFFEID` admission webhook is served by the `spire-controller-manager`, which runs as a **sidecar container inside the `spire-server-0` pod**.

The existing `isPodReady("app.kubernetes.io/name=server")` call waits for the pod's readiness probe to pass, but the pod can be "Available" before the controller-manager sidecar's webhook server is ready to accept TLS connections. This produces the error seen in CI:

```
Internal error occurred: failed calling webhook "vclusterspiffeid.kb.io": failed to call webhook:
Post "https://spire-controller-manager-webhook.spire-system.svc:443/...":
no endpoints available for service "spire-controller-manager-webhook"
```

The `YamlK8s` installer retries for 30×3s=90s, but the webhook remained unavailable for ~96s in loaded CI environments, causing the test to fail.

## Fix

Added an explicit `k8s.WaitUntilServiceAvailable` call for the `spire-controller-manager-webhook` service in `test/framework/deployments/spire/kubernetes.go`, after the existing pod readiness checks. This directly waits for the webhook service to have endpoints (i.e., the controller-manager sidecar is ready and accepting connections) before `Deploy()` returns.

The wait uses `DefaultRetries*3 × DefaultTimeout` (90 retries × 3s = 270s), consistent with the other SPIRE waits in the same function.

## Why This Fix Is Stable

- It targets the exact resource that was unavailable (`spire-controller-manager-webhook` service endpoints)
- It uses the same generous timeout already in place for other SPIRE components
- The fix is in the shared framework deployment (`kubernetes.go`), so it benefits any future test that installs SPIRE on k8s

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)