### PR TITLE
docs(e2e): clarify mise race condition comment in test/e2e/k8s/start

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -93,9 +93,14 @@ test/e2e/list:
 .PHONY: test/e2e/k8s/start
 test/e2e/k8s/start:
 	# Pre-install all mise tools serially before parallel cluster starts.
-	# Without this, parallel make subprocesses race to auto-install tools
-	# excluded by MISE_DISABLE_TOOLS (e.g. golangci-lint) when they parse
-	# mk/dev.mk, causing EEXIST failures on the runtime symlink creation.
+	# The jdx/mise-action step sets MISE_DISABLE_TOOLS=golangci-lint,skaffold
+	# (scoped to that step only), so those tools are absent when this recipe
+	# runs. Each parallel sub-make re-parses mk/dev.mk and evaluates
+	# $(shell $(MISE) which golangci-lint), which triggers mise auto-install.
+	# Two parallel processes racing to create the runtime symlink fail with:
+	#   mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest (EEXIST)
+	# Running $(MISE) install first ensures tools are present before any
+	# subprocess parses the Makefile, eliminating the race condition.
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets


### PR DESCRIPTION
## What was causing the flake

**Root cause**: Race condition during parallel `make k3d/start` invocations.

The `jdx/mise-action` step sets `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` scoped only to that step. When the "Run E2E tests" step runs `test/e2e-multizone` → `test/e2e/k8s/start`, the parallel sub-makes (`$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)`) each re-parse the full Makefile and evaluate `$(shell $(MISE) which golangci-lint)` from `mk/dev.mk:78`. Since golangci-lint was not installed (skipped by the setup step), mise auto-install triggered simultaneously in both processes, and both raced to create the `golangci-lint/latest` runtime symlink:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest (EEXIST)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## What was changed

The functional fix (`$(MISE) install` before `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)`) was already applied in prior commits. This PR rewrites the comment in `test/e2e/k8s/start` to accurately describe **why** `$(MISE) install` is necessary:

- **Before**: "parallel make subprocesses race to auto-install tools *excluded by MISE_DISABLE_TOOLS*" — misleading because `MISE_DISABLE_TOOLS` is NOT set during the "Run E2E tests" step
- **After**: explains the full chain (jdx/mise-action scopes MISE_DISABLE_TOOLS to itself → tools are absent → parallel sub-makes trigger auto-install → EEXIST race)

## Why the fix is stable

An accurate comment prevents future developers from misreading it as "MISE_DISABLE_TOOLS is set, so $(MISE) install is redundant" and accidentally removing the guard that prevents the race.

> Changelog: skip