### PR TITLE
docs(e2e): document mise install prerequisite in test/e2e/debug

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -111,6 +111,10 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
 test/e2e/debug: $(E2E_DEPS_TARGETS)
+	# Pre-install all mise tools serially before parallel cluster starts.
+	# Without this, parallel make subprocesses race to auto-install tools
+	# excluded by MISE_DISABLE_TOOLS (e.g. golangci-lint) when they parse
+	# mk/dev.mk, causing EEXIST failures on the runtime symlink creation.
 	$(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag


### PR DESCRIPTION
## Summary

- Adds explanatory comment to `test/e2e/debug` explaining why `$(MISE) install` must run before the parallel cluster start invocation
- Makes `test/e2e/debug` consistent with `test/e2e/k8s/start`, which already had this comment (added in abfbe75a)
- Prevents future accidental removal of the `$(MISE) install` that guards against EEXIST race conditions

## Root cause of the flake (issue #34)

**Job:** `test_e2e_env (v1.31.12-k3s1, multizone, amd64) / e2e (0)`

The `test/e2e-multizone` target calls `test/e2e/k8s/start`, which launches `kuma-1` and `kuma-2` cluster setups in parallel via `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)`. Each cluster start spawns a sub-`make` process that fully parses `mk/dev.mk`, evaluating expressions like `$(shell $(MISE) which golangci-lint)`.

In CI, the `jdx/mise-action` step runs with `MISE_DISABLE_TOOLS="golangci-lint,skaffold"`, so those tools are **not** pre-installed. When the two parallel sub-makes both hit `$(shell $(MISE) which golangci-lint)`, mise auto-install triggers concurrently in both processes. Both race to create the runtime symlink:

```
mise ERROR failed to ln -sf ./2.11.3 golangci-lint/latest
mise ERROR File exists (os error 17)
make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
make[1]: *** [mk/e2e.new.mk:82: test/e2e/k8s/start/cluster/kuma-2] Error 2
```

## What was changed and why

The infrastructure fix was applied in earlier commits:
- `98f26106b`: Added `$(MISE) install` to `test/e2e/k8s/start` before parallel cluster starts
- `006d85c55`: Restored `-j` parallelism after adding the serial pre-install step
- `7bd4a5c5d`: Added `$(MISE) install` to `test/e2e/debug` for the same reason

`$(MISE) install` runs **without** `MISE_DISABLE_TOOLS` (that env var is only in the `jdx/mise-action` step, not in "Run E2E tests"), so it installs ALL tools including golangci-lint. After this, parallel sub-makes find the tools already installed and make no filesystem modifications.

This PR adds the same explanatory comment to `test/e2e/debug` that `test/e2e/k8s/start` already has, documenting why the `$(MISE) install` is essential.

## Why the fix is stable

`$(MISE) install` is idempotent — it is a no-op when all tools are already installed. Running it serially before parallel cluster starts eliminates the race condition entirely: all symlinks are created before any parallel subprocess can attempt to create them.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)