### PR TITLE
docs(e2e): explain why webhook endpoint wait is needed in spire Deploy

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -72,6 +72,13 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
+	// Wait for the spire-controller-manager webhook Endpoints to have at least one
+	// ready address before returning. The controller-manager may run as a sidecar
+	// inside spire-server-0 or as a standalone pod depending on the helm chart
+	// version. Using the Endpoints object (rather than a pod selector) makes this
+	// robust to both topologies: the endpoint controller only populates addresses
+	// after the container's readiness probe passes, ensuring the webhook is
+	// accepting requests before BeforeAll applies any ClusterSPIFFEID resources.
 	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
 }
 


### PR DESCRIPTION
## Root Cause

The `BeforeAll` in `test/e2e_env/kubernetes/meshidentity/spire.go` installs SPIRE via Helm, then immediately applies a `ClusterSPIFFEID` resource via `YamlK8s(workflowRegistration)`. The `ClusterSPIFFEID` admission webhook is served by the **spire-controller-manager**, which runs as a sidecar in the `spire-server-0` pod.

The existing `isPodReady("app.kubernetes.io/name=server")` waits for the pod's readiness probe to pass, but the controller-manager sidecar can bind its TLS webhook server *after* the pod is considered "Available". This produces the error seen in CI:

```
Internal error occurred: failed calling webhook "vclusterspiffeid.kb.io": failed to call webhook:
Post "https://spire-controller-manager-webhook.spire-system.svc:443/...":
no endpoints available for service "spire-controller-manager-webhook"
```

The `YamlK8s` installer retried for 30×3s=90s, but on loaded CI runners the webhook remained unavailable for ~96s, causing `BeforeAll` to fail at `spire.go:58`.

## What Was Changed

The actual fix (`waitForWebhookEndpoints`) was already added in a prior commit. This PR adds an explanatory comment at the call site in `test/framework/deployments/spire/kubernetes.go` documenting **why** pod readiness alone is insufficient and what race condition the endpoint wait prevents. This helps future maintainers understand the fix without having to dig through git history.

## Why the Fix Is Stable

`waitForWebhookEndpoints` polls the `spire-controller-manager-webhook` Endpoints object until at least one ready address is present (up to `DefaultRetries*3 = 90` polls × 3s = 4.5 minutes). Once the endpoint is registered, the webhook server is listening and will accept `ClusterSPIFFEID` admission requests on the first attempt. The `YamlK8s` retry budget (30×3s=90s) then serves only as a safety net for transient errors, not for absorbing startup latency.

Closes #31