### PR TITLE
fix(e2e): use method chain for MustPassRepeatedly in spire test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "2m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",


### PR DESCRIPTION
## Root Cause

In `test/e2e_env/kubernetes/meshidentity/spire.go`, the traffic-check `Eventually` block used:

```go
}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
```

`MustPassRepeatedly(5)` here refers to **Ginkgo's node decorator** (imported via `. "github.com/onsi/ginkgo/v2"`), not Gomega's `AsyncAssertion.MustPassRepeatedly()` method. Gomega's `Eventually()` accepts `args ...any` and silently ignores unrecognised positional arguments. As a result:

- The 2 m timeout IS applied (string positional args are parsed as durations)
- The 5-consecutive-pass requirement is **NOT** applied — the assertion succeeds on the very first successful response

On loaded CI runners, SPIRE certificate distribution and Envoy SDS reconfiguration can take time. A single successful response doesn't prove traffic is stable; it may be a transient success before the full pipeline is ready. The missing consecutive-pass check makes the test pass prematurely and then fail downstream.

## What Changed

Single-line fix in `spire.go`:

```go
// Before (MustPassRepeatedly silently ignored)
}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())

// After (method chain — Gomega's MustPassRepeatedly honoured)
}, "2m", "1s").MustPassRepeatedly(5).Should(Succeed())
```

## Why the Fix Is Stable

`AsyncAssertion.MustPassRepeatedly(5)` requires 5 consecutive passes within the 2 m window before declaring success. This ensures traffic is genuinely stable after SPIRE completes certificate issuance and Envoy reconfigures its SDS listener, eliminating transient-success false-passes.

Fixes #16