### PR TITLE
fix(e2e): use method chain for MustPassRepeatedly in spire test

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -119,7 +119,7 @@ spec:
 			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
-		}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		}, "2m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		admin, err := kubernetes.Cluster.GetOrCreateAdminTunnel(portforward.Spec{
 			AppName:   "test-server",


### PR DESCRIPTION
## Root Cause

In `test/e2e_env/kubernetes/meshidentity/spire.go`, the traffic-check `Eventually` block used:

```go
}, "2m", "1s", MustPassRepeatedly(5)).Should(Succeed())
```

The dot-import of `ginkgo/v2` brings Ginkgo's `MustPassRepeatedly` node decorator into scope. Gomega's `Eventually` only recognises `(timeout, pollingInterval, context)` as positional args — it silently ignores `MustPassRepeatedly(5)`. The 5-consecutive-pass requirement was never applied: the assertion passed on the first successful response, even when SPIRE certificate distribution wasn't fully complete yet.

## What Was Changed

Changed the positional-arg form to the method-chain form:

```go
}, "2m", "1s").MustPassRepeatedly(5).Should(Succeed())
```

## Why the Fix Is Stable

`AsyncAssertion.MustPassRepeatedly(5)` requires 5 consecutive passes within the 2-minute window before declaring success. This ensures traffic is genuinely stable after SPIRE certificate issuance and Envoy SDS reconfiguration, eliminating transient-success false-passes on slow CI runners.

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)