### PR TITLE
fix(e2e): keep Envoy connection open with partial HTTP headers in gateway resources test

### DIFF
--- a/test/e2e_env/kubernetes/gateway/resources.go
+++ b/test/e2e_env/kubernetes/gateway/resources.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -121,21 +123,30 @@ spec:
 		defer GinkgoRecover()
 
 		var demoClientPod string
+		// Use a 5m timeout to tolerate the old pod remaining in Terminating
+		// state for an extended period after KillAppPod, which causes
+		// PodNameOfApp to see 2 pods (old Terminating + new Running) and
+		// fail until the old one is fully removed.
 		Eventually(func(g Gomega) {
 			var err error
 			demoClientPod, err = PodNameOfApp(kubernetes.Cluster, "demo-client", waitingClientNamespace)
 			g.Expect(err).ToNot(HaveOccurred())
-		}, "2m", "1s").Should(Succeed())
+		}, "5m", "1s").Should(Succeed())
 
 		cmd := []string{"telnet", gatewayHost, "8080"}
-		// We pass in a stdin that blocks so that telnet will keep the
-		// connection open
+		// Send a partial HTTP request (request line + Host header, no
+		// terminating blank line) so that Envoy keeps the TCP connection
+		// open waiting for the rest of the headers. Without this, a raw
+		// connection with no HTTP data may be closed by Envoy before
+		// MustPassRepeatedly can accumulate the required number of
+		// consecutive failures.
+		partialHTTP := []byte(fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\n", gatewayHost))
 		_, _, _ = kubernetes.Cluster.ExecWithOptions(ExecOptions{
 			Command:            cmd,
 			Namespace:          waitingClientNamespace,
 			PodName:            demoClientPod,
 			ContainerName:      "demo-client",
-			Stdin:              &BlockingReader{},
+			Stdin:              io.MultiReader(bytes.NewReader(partialHTTP), &BlockingReader{}),
 			CaptureStdout:      true,
 			CaptureStderr:      true,
 			PreserveWhitespace: false,


### PR DESCRIPTION
## Root Cause

The `Resources` / `connection limit is respected` test in `test/e2e_env/kubernetes/gateway/resources.go` has two race conditions in `keepConnectionOpen`:

**1. Envoy closing raw TCP connections with no HTTP data**

The original `keepConnectionOpen` passed `&BlockingReader{}` as stdin to `telnet`. Envoy's HTTP listener has an implicit request-headers timeout — a raw TCP connection that never sends any HTTP data can be closed by Envoy before `MustPassRepeatedly(3)` accumulates 3 consecutive curl failures. When that connection slot frees up, subsequent curl requests succeed (making the test unstable).

**2. Old pod in Terminating state after KillAppPod**

After `KillAppPod`, the old `demo-client` pod lingers in `Terminating` state for up to ~30s. `PodNameOfApp` returns an error when it sees 2 pods (old Terminating + new Running). The prior 2m `Eventually` timeout was sometimes insufficient on slow CI nodes, causing `keepConnectionOpen` to time out and exit before establishing a connection — leaving 0 persistent connections held, so all curl requests succeed.

## Changes

1. **Partial HTTP request as stdin**: replaced `&BlockingReader{}` with `io.MultiReader(bytes.NewReader(partialHTTP), &BlockingReader{})` where `partialHTTP` is `"GET / HTTP/1.1\r\nHost: <gatewayHost>\r\n"`. Envoy receives valid request headers but waits indefinitely for the request body terminator, keeping the connection open reliably.

2. **Increased PodNameOfApp timeout from 2m → 5m**: gives the old Terminating pod enough time to be fully removed before `PodNameOfApp` returns exactly 1 result.

## Why the Fix is Stable

- Envoy will not close an HTTP connection that has received a valid partial request and is still waiting for more headers — there is no reason to close it until its own per-stream timeout fires (much longer than the test window).
- 5 minutes is well beyond the Kubernetes default graceful termination period (30s) plus scheduling delays, effectively eliminating the second race window.

Fixes #16