### PR TITLE
fix(e2e): increase k3d/wait timeout for flannel cluster startup

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -227,7 +227,7 @@ k3d/configure/metallb:
 .PHONY: k3d/wait
 k3d/wait:
 	@TIMES_TRIED=0; \
-	MAX_ALLOWED_TRIES=30; \
+	MAX_ALLOWED_TRIES=60; \
 	until KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; do \
 		echo "Waiting for the cluster to come up" && sleep 1; \
 		TIMES_TRIED=$$((TIMES_TRIED+1)); \


### PR DESCRIPTION
## Root Cause

The `k3d/wait` target in `mk/k3d.mk` polls for all `kube-system` pods to be Ready with a hard limit of 30 retries × ~6s each ≈ **3 minutes**. The CI failure in #127 shows two overlapping timing issues:

1. **Flannel not ready**: `plugin type="flannel" failed (add): loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory` — flannel's DaemonSet took longer than 3 min to write `/run/flannel/subnet.env`, so other pods (like `local-path-provisioner`) couldn't start their sandboxes.
2. **Docker Hub TLS timeout**: `Failed to pull image "rancher/local-path-provisioner:v0.0.32": ... TLS handshake timeout` — the image pull itself timed out, putting the pod into `ImagePullBackOff`.

Both issues are transient and self-heal given enough time; the cluster just needed more runway.

## What Changed

Increased `MAX_ALLOWED_TRIES` from `30` to `60` in `k3d/wait`, extending the maximum wait from ~3 minutes to ~6 minutes.

## Why This Should Be Stable

- Flannel initialization and Docker Hub image pulls are the bottleneck, not test logic.
- 6 minutes is well within K8s image-pull backoff cycles, giving the cluster enough time to recover from transient network delays.
- All other parallel shards (0, 2, 3) of the same job passed in the same CI run, confirming this is a timing-only flake.

Closes #127