### PR TITLE
fix(e2e): increase k3d/wait MAX_ALLOWED_TRIES from 30 to 60

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -227,7 +227,7 @@ k3d/configure/metallb:
 .PHONY: k3d/wait
 k3d/wait:
 	@TIMES_TRIED=0; \
-	MAX_ALLOWED_TRIES=30; \
+	MAX_ALLOWED_TRIES=60; \
 	until KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; do \
 		echo "Waiting for the cluster to come up" && sleep 1; \
 		TIMES_TRIED=$$((TIMES_TRIED+1)); \


### PR DESCRIPTION
## Summary

- Increases `MAX_ALLOWED_TRIES` in the `k3d/wait` target from `30` to `60`, extending the cluster readiness window from ~180s to ~360s

## Root Cause

The CI job `test / test_e2e (v1.34.1-k3s1, amd64, 4, flannel) / e2e (1)` failed during k3d cluster startup with two overlapping transient issues:

1. **Flannel initialization delay**: `loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory` — flannel's DaemonSet took ~3m15s to write its subnet config, just 15 seconds past the old 3-minute window. Other pods couldn't create pod sandboxes until flannel was ready.
2. **Docker Hub TLS timeout**: `rancher/local-path-provisioner:v0.0.32` hit a TLS handshake timeout and entered `ImagePullBackOff`.

The `k3d/wait` target iterates with `kubectl wait --timeout=5s` + `sleep 1` ≈ 6s per iteration. With `MAX_ALLOWED_TRIES=30`, the maximum wait is ~180s — not enough for flannel on flannel-CNI clusters.

## What Changed

`mk/k3d.mk:230`: `MAX_ALLOWED_TRIES=30` → `MAX_ALLOWED_TRIES=60`

## Why This Should Be Stable

- Both failures are transient and self-heal: flannel eventually writes its subnet file, and `ImagePullBackOff` retries succeed after the Docker Hub timeout clears
- The 6-minute window comfortably covers the observed 3m15s flannel delay
- Real failures still surface: if the cluster genuinely can't start within 6 minutes, the diagnostic dump (kubectl describe + logs) fires and the job fails with useful output
- Matches the pattern from `fde49b34c` (increased MetalLB readiness timeout for the same reason on Calico clusters)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)