### PR TITLE
fix(e2e): increase k3d/wait MAX_ALLOWED_TRIES from 30 to 60

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -227,7 +227,7 @@ k3d/configure/metallb:
 .PHONY: k3d/wait
 k3d/wait:
 	@TIMES_TRIED=0; \
-	MAX_ALLOWED_TRIES=30; \
+	MAX_ALLOWED_TRIES=60; \
 	until KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; do \
 		echo "Waiting for the cluster to come up" && sleep 1; \
 		TIMES_TRIED=$$((TIMES_TRIED+1)); \


### PR DESCRIPTION
## Summary

- Increases `MAX_ALLOWED_TRIES` from `30` to `60` in `mk/k3d.mk` (`k3d/wait` target)
- Extends the maximum cluster readiness wait from ~180s to ~360s (6 minutes)

Fixes #127

## Root Cause

The CI job `test / test_e2e (v1.34.1-k3s1, amd64, 4, flannel) / e2e (1)` failed during k3d cluster startup. Two overlapping transient issues caused kube-system pods to take longer than the 3-minute window:

1. **Flannel initialization**: `loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory` — flannel's DaemonSet took ~3m15s to write its subnet config. Other pods (`local-path-provisioner`) couldn't create pod sandboxes until flannel was ready.
2. **Docker Hub TLS timeout**: The `rancher/local-path-provisioner:v0.0.32` image pull hit a TLS handshake timeout and entered `ImagePullBackOff`.

The `k3d/wait` target uses `kubectl wait --timeout=5s` + `sleep 1` per iteration, so 30 tries = ~180s maximum. Flannel took 195s — just 15 seconds over the limit.

## What Changed

`MAX_ALLOWED_TRIES=30` → `MAX_ALLOWED_TRIES=60` in `mk/k3d.mk:230`.

## Why This Should Be Stable

- Both failures are transient and self-heal with more time
- The 6-minute window covers the observed 3m15s flannel delay and allows `ImagePullBackOff` cycles to recover (Kubernetes' exponential backoff caps at ~5 minutes)
- Real failures still surface: the diagnostic dump (kubectl describe + logs) fires at the retry limit
- Matches the pattern from commit `fde49b34c` which increased MetalLB readiness timeout for similar transient timing issues

## Test plan

- [ ] CI passes on the `test / test_e2e (v1.34.1-k3s1, amd64, 4, flannel)` job
- [ ] No regression in other CNI configurations (calico, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)