### PR TITLE
fix(e2e): remove spire-controller-manager pod check that blocks BeforeAll

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -71,11 +71,6 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
-	if err != nil {
-		return err
-	}
-
 	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
 }
 


### PR DESCRIPTION
## Summary

Fixes flaky test `kubernetes/meshidentity/spire It` (issue #32).

- Removes the `isPodReady("app.kubernetes.io/name=spire-controller-manager")` call that was re-introduced in b445225e3

## Root Cause

In the current version of the SPIRE hardened helm chart, the `spire-controller-manager` runs as a **sidecar container inside the spire-server pod** rather than as a standalone Deployment. There is no pod with the label `app.kubernetes.io/name=spire-controller-manager`, so `WaitUntilNumPodsCreatedE` retries for the full 90×3s=270s window and then fails.

This check was previously removed in `03db5d87d` for exactly this reason, then mistakenly re-added in `b445225e3`. PR #36 ran into this regression.

## What Changed

In `test/framework/deployments/spire/kubernetes.go`:
- Removed the `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` block

## Why the Fix Is Stable

`waitForWebhookEndpoints("spire-controller-manager-webhook")` — already present — polls the Kubernetes `Endpoints` object for the webhook service and only succeeds when at least one ready address is present. This is a stronger signal than pod existence: it confirms the controller-manager sidecar (inside the spire-server pod) is actually serving the admission webhook. The spire-server pod is already checked via `isPodReady(cluster, "app.kubernetes.io/name=server")`, so we have full coverage without the bogus standalone-pod check.

Closes #32

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)