### PR TITLE
fix(e2e): increase k3d/wait timeout from 3m to 6m for flannel clusters

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -227,7 +227,7 @@ k3d/configure/metallb:
 .PHONY: k3d/wait
 k3d/wait:
 	@TIMES_TRIED=0; \
-	MAX_ALLOWED_TRIES=30; \
+	MAX_ALLOWED_TRIES=60; \
 	until KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; do \
 		echo "Waiting for the cluster to come up" && sleep 1; \
 		TIMES_TRIED=$$((TIMES_TRIED+1)); \


### PR DESCRIPTION
## Summary

- Increased `MAX_ALLOWED_TRIES` from `30` to `60` in `mk/k3d.mk` `k3d/wait` target
- Extends the maximum cluster readiness window from ~180s to ~360s (6 minutes)

Fixes #127

## Root Cause

The `k3d/wait` target gave only ~3 minutes (30 retries × ~6s) for all `kube-system` pods to become Ready. The CI failure showed two overlapping transient startup delays on flannel clusters:

1. **Flannel initialization**: `loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory` — flannel's DaemonSet took ~3m15s (195s) to write its subnet config, just 15 seconds over the 3-minute limit. Other pods (`local-path-provisioner`) couldn't create pod sandboxes until flannel was ready.
2. **Docker Hub TLS timeout**: The `rancher/local-path-provisioner:v0.0.32` image pull hit a TLS handshake timeout and entered `ImagePullBackOff`.

## What Changed

`MAX_ALLOWED_TRIES` increased from `30` to `60` in `mk/k3d.mk:230`, extending the maximum wait to ~360s (6 minutes).

## Why This Should Be Stable

Both failures are transient and self-heal with more time. The 6-minute window comfortably covers the observed 195s flannel delay and allows `ImagePullBackOff` retry cycles to recover. Real cluster failures still surface through the diagnostic dump (kubectl describe + logs) that fires at the retry limit.

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)