### PR TITLE
fix(e2e): increase k3d/wait timeout from 3m to 6m for flannel clusters

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -227,7 +227,7 @@ k3d/configure/metallb:
 .PHONY: k3d/wait
 k3d/wait:
 	@TIMES_TRIED=0; \
-	MAX_ALLOWED_TRIES=30; \
+	MAX_ALLOWED_TRIES=60; \
 	until KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; do \
 		echo "Waiting for the cluster to come up" && sleep 1; \
 		TIMES_TRIED=$$((TIMES_TRIED+1)); \


### PR DESCRIPTION
## Summary

- Increases `MAX_ALLOWED_TRIES` from `30` to `60` in the `k3d/wait` target (`mk/k3d.mk`)
- Extends the maximum wait window for `kube-system` pods from ~180s to ~360s

## Root Cause

The CI job `test / test_e2e (v1.34.1-k3s1, amd64, 4, flannel) / e2e (1)` failed during k3d cluster startup. With `MAX_ALLOWED_TRIES=30` and a 5s kubectl wait + 1s sleep per iteration, the total wait is ~180s (3 minutes). The failure showed two overlapping transient delays:

1. **Flannel initialization**: `loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory` — flannel's DaemonSet took 3m15s to write its subnet config, 15 seconds over the limit. Other pods couldn't create pod sandboxes until flannel was ready.
2. **Docker Hub TLS timeout**: `rancher/local-path-provisioner:v0.0.32` hit a TLS handshake timeout and entered `ImagePullBackOff`.

## What Changed

`MAX_ALLOWED_TRIES` increased from `30` to `60` in `mk/k3d.mk:230`, extending the maximum wait to ~360s (6 minutes).

## Why This Should Be Stable

Both failures are transient and self-heal with more time. The 6-minute window comfortably covers the observed 3m15s flannel delay and allows `ImagePullBackOff` cycles to recover through Kubernetes' retry backoff. Real failures (genuinely broken cluster) still surface through the diagnostic dump (kubectl describe + logs) when the limit is reached.

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)