### PR TITLE
fix(e2e): remove spire-controller-manager pod readiness check

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -71,11 +71,10 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = t.isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")
-	if err != nil {
-		return err
-	}
-
+	// spire-controller-manager runs as a sidecar inside the spire-server pod,
+	// not as a standalone Deployment, so there is no pod with the label
+	// app.kubernetes.io/name=spire-controller-manager. Waiting for
+	// webhook endpoints is a stronger and correct readiness signal.
 	return t.waitForWebhookEndpoints(cluster, "spire-controller-manager-webhook")
 }
 


### PR DESCRIPTION
## Summary

- `spire-controller-manager` runs as a **sidecar** inside the `spire-server` pod, not as a standalone Deployment. The `isPodReady` check with selector `app.kubernetes.io/name=spire-controller-manager` waits for a pod that never appears, causing `WaitUntilNumPodsCreatedE` to time out (~270s) and fail `BeforeAll` with `retry.MaxRetriesExceeded`.
- This blocked CI verification of the issue #16 fix: the sidecarContainers E2E job runs the spire MeshIdentity test, and this check caused that test's `BeforeAll` to always fail.
- Replace the broken check with `waitForWebhookEndpoints("spire-controller-manager-webhook")`, which polls the Endpoints object and returns only when the sidecar is actually serving admission webhook requests — a stronger and correct readiness signal.

## Test plan

- [ ] CI passes for `test_e2e_env (sidecarContainers, ...)` and `test_e2e_env (kubernetes, ...)` with the spire MeshIdentity test succeeding in `BeforeAll`
- [ ] `waitForWebhookEndpoints` provides sufficient readiness guarantee before `ClusterSPIFFEID` is applied

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)