### PR TITLE
fix(ci): wait for flannel subnet.env before k3d cluster readiness check

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -183,10 +183,22 @@ k3d/configure/cni: k3d/configure/cni/$(K3D_NETWORK_CNI_EFFECTIVE)
 	  echo "[WARNING]: Unsupported K3D CNI '$(K3D_NETWORK_CNI_REQ)', falling back to '$(K3D_NETWORK_CNI_DEFAULT)'" >&2; \
 	fi
 
-# Default: flannel (no action required)
+# Default: flannel - wait for subnet.env to exist before continuing.
+# k3s writes /run/flannel/subnet.env when the flannel VXLAN is ready; pods
+# that need to create a network sandbox will fail with
+# "loadFlannelSubnetEnv: no such file or directory" until that file appears.
 .PHONY: k3d/configure/cni/flannel
 k3d/configure/cni/flannel:
-	@true
+	@echo "Waiting for flannel subnet.env on k3d node..."; \
+	for i in $$(seq 1 60); do \
+		if docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 test -f /run/flannel/subnet.env 2>/dev/null; then \
+			echo "flannel subnet.env is ready (attempt $$i)"; \
+			exit 0; \
+		fi; \
+		echo "  attempt $$i/60 – not ready yet, sleeping 5s..."; \
+		sleep 5; \
+	done; \
+	echo "Timeout waiting for flannel subnet.env"; exit 1
 
 # Calico (runs when K3D_NETWORK_CNI=calico)
 .PHONY: k3d/configure/cni/calico


### PR DESCRIPTION
## Root cause

The `k3d/configure/cni/flannel` target was a no-op (`@true`). In k3s, the flannel CNI plugin is built into the agent, which writes `/run/flannel/subnet.env` only after the VXLAN interface is fully initialized. Any pod that tries to create a network sandbox before this file exists fails with:

```
plugin type="flannel" failed (add): loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory
```

In the [failing CI run](https://github.com/kumahq/kuma/actions/runs/23332486988), flannel took ~3m15s to write this file. The `k3d/wait` readiness loop (previously capped at ~180s with `MAX_ALLOWED_TRIES=30`) expired before flannel was ready. `local-path-provisioner` couldn't create its pod sandbox and also hit a Docker Hub TLS timeout on image pull, entering `ImagePullBackOff`.

## What changed

Added a targeted poll in `k3d/configure/cni/flannel` (which runs *before* `k3d/wait`) that waits up to 5 minutes for `/run/flannel/subnet.env` to exist on the k3d server node:

```makefile
k3d/configure/cni/flannel:
    @echo "Waiting for flannel subnet.env on k3d node..."; \
    for i in $$(seq 1 60); do \
        if docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 test -f /run/flannel/subnet.env 2>/dev/null; then \
            echo "flannel subnet.env is ready (attempt $$i)"; \
            exit 0; \
        fi; \
        ...
    done
```

The existing `MAX_ALLOWED_TRIES=60` increase (commit `a280979eb`) is kept as a second safety net.

## Why this is stable

- The flannel wait is **targeted**: it polls the specific root cause (the subnet file) rather than relying on generic pod readiness retries to cover it.
- Runs **before** `k3d/wait`, so by the time kube-system pod readiness is checked, the network layer is guaranteed to be initialized and pods can create sandboxes.
- 60 × 5s = 5 minutes max covers the observed 3m15s delay with room to spare.
- Real cluster failures (flannel never starts) still surface — the loop exits non-zero after 60 attempts.

Fixes #127