### PR TITLE
docs(e2e): include webhook name in spire retry description

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -2,6 +2,7 @@ package spire
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -84,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr


### PR DESCRIPTION
## Root Cause

Issue #16 (`sidecarContainers` CI job) had two independent root causes, both now fixed on master:

1. **mise symlink race** (commit `70bf11863`): parallel `make -j kuma-1 kuma-2` subprocess processes raced to create `/home/ubuntu/.local/share/mise/installs/skaffold/latest` symlink, failing with `EEXIST`. Fixed by adding a serial `MISE_DISABLE_TOOLS= $(MISE) install` step before the parallel cluster starts in `mk/e2e.new.mk`.

2. **spire-controller-manager pod check** (commit `c134a27f4`): `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` waited for a pod that never exists — `spire-controller-manager` runs as a sidecar inside the `spire-server` pod. Fixed by replacing with `waitForWebhookEndpoints("spire-controller-manager-webhook")`.

## What Was Changed

The `waitForWebhookEndpoints` retry description was `"wait for webhook endpoints"` — it did not include the specific webhook name. CI logs showing this retry polling are ambiguous when multiple webhooks are involved. This PR includes the `webhookName` argument in the retry description string for clearer log output.

## Why the Fix Is Stable

This is a pure logging/observability improvement. It does not change any timeout, retry count, or logic — only the descriptive string passed to `retry.DoWithRetryE`. The `fmt.Sprintf` is straightforward and cannot fail.

Closes #16

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)