### PR TITLE
docs(e2e): include webhook name in spire retry description

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -2,6 +2,7 @@ package spire
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -84,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr


### PR DESCRIPTION
## Summary

Issue #16 (`sidecarContainers` CI job) had two independent root causes, both already fixed on master:

1. **mise symlink race** (commit `70bf11863`): parallel `make -j kuma-1 kuma-2` subprocess processes raced to create the skaffold runtime symlink, failing with `EEXIST`. Fixed by adding a serial `MISE_DISABLE_TOOLS= $(MISE) install` step before parallel cluster starts in `mk/e2e.new.mk`.

2. **spire-controller-manager pod check** (commit `c134a27f4`): `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")` waited for a pod that never exists — `spire-controller-manager` runs as a sidecar inside the `spire-server` pod, not as a standalone Deployment. Fixed by replacing with `waitForWebhookEndpoints("spire-controller-manager-webhook")`.

This PR adds a minor observability improvement: the `waitForWebhookEndpoints` retry description was the generic string `"wait for webhook endpoints"`. This PR includes the `webhookName` argument so CI logs show exactly which webhook is being awaited, making future failures easier to diagnose.

## Root Cause

The two root causes of issue #16:

1. **mise EEXIST race**: `test/e2e/k8s/start` ran kuma-1 and kuma-2 as parallel make prerequisites. Each sub-make subprocess parsed `mk/dev.mk`, evaluating `$(shell $(MISE) which skaffold)`. Since `MISE_DISABLE_TOOLS=golangci-lint,skaffold` was set during initial `jdx/mise-action` setup, those tools were not pre-installed. Both subprocesses raced to auto-install skaffold and create its runtime symlink, failing with `File exists (os error 17)`.

2. **spire-controller-manager pod check**: The `Deploy` method in `spire/kubernetes.go` called `isPodReady(cluster, "app.kubernetes.io/name=spire-controller-manager")`, which waited for a pod with that label. Since `spire-controller-manager` runs as a sidecar inside the `spire-server` pod (no standalone Deployment with that label), the wait always timed out after `DefaultRetries*3 × DefaultTimeout = 270s`.

## What Was Changed

Included `webhookName` in the `retry.DoWithRetryE` description string for `waitForWebhookEndpoints`.

## Why the Fix Is Stable

This is a pure logging/observability improvement with no logic changes. It does not affect any timeout, retry count, or behavior.

Closes #16

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)