### PR TITLE
fix(e2e): include webhook name in spire retry description

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -2,6 +2,7 @@ package spire
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -84,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr


### PR DESCRIPTION
## Summary

- The `waitForWebhookEndpoints` retry description was the static string `"wait for webhook endpoints"`, making it hard to identify which webhook was not ready when CI logs show retries.
- Include `webhookName` in the description so failures clearly say e.g. `"wait for spire-controller-manager-webhook webhook endpoints"`.

## Root Cause

Issue #16 (`sidecarContainers` CI job) had two independent root causes, both now fixed on master:

1. **mise symlink race** (commit `70bf11863`): parallel `make -j kuma-1 kuma-2` subprocess processes raced to create the `/home/ubuntu/.local/share/mise/installs/skaffold/latest` symlink, failing with `EEXIST`. Fixed by adding a serial `MISE_DISABLE_TOOLS= $(MISE) install` step before the parallel cluster starts in `mk/e2e.new.mk`.

2. **spire-controller-manager pod readiness check** (commit `c134a27f4`): `spire-controller-manager` runs as a sidecar inside the `spire-server` pod, not as a standalone Deployment. The previous `isPodReady("app.kubernetes.io/name=spire-controller-manager")` check waited for a pod that never exists. Fixed by replacing it with `waitForWebhookEndpoints("spire-controller-manager-webhook")`.

## What this PR changes

- Improves the retry description in `waitForWebhookEndpoints` to include the specific webhook name, making CI log output clearer when the check fails or retries.

## Test plan
- [ ] CI passes for `test_e2e_env (sidecarContainers, ...)` and `test_e2e_env (kubernetes, ...)` with the spire MeshIdentity test succeeding

> Changelog: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)