### PR TITLE
fix(e2e): include webhook name in spire retry description

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -2,6 +2,7 @@ package spire
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -84,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for webhook endpoints %q", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr


### PR DESCRIPTION
## Summary

Fixes #16

- Includes the webhook name in the `retry.DoWithRetryE` description in `waitForWebhookEndpoints` so CI logs clearly show which webhook is being waited for.

## Root Cause

The `test / test_e2e_env (sidecarContainers, v1.34.1-k3s1, kubernetes, amd64) / e2e (0)` job failed due to a **race condition in parallel `make` invocations**:

1. `test/e2e/k8s/start` ran `kuma-1` and `kuma-2` as parallel make prerequisites.
2. Both spawned subprocesses triggered `mise` auto-install simultaneously and raced to create the runtime symlink, producing: `mise ERROR failed to ln -sf ./2.18.0 .../skaffold/latest` / `File exists (os error 17)`.

The core fix (`MISE_DISABLE_TOOLS= $(MISE) install` before parallel cluster starts in `mk/e2e.new.mk`) was already applied in earlier commits on master.

Additionally, the `spire-controller-manager` pod readiness check was removed (it was waiting for a pod that never appears since spire-controller-manager runs as a sidecar in the spire-server pod), replaced with `waitForWebhookEndpoints`.

## What Was Changed

This PR makes an additional observability improvement: it includes the `webhookName` in the retry description for `waitForWebhookEndpoints` in `test/framework/deployments/spire/kubernetes.go`, changing:

```
"wait for webhook endpoints"
```

to:

```
"wait for webhook endpoints \"spire-controller-manager-webhook\""
```

This makes CI log output immediately clear which component is slow to start, aiding diagnosis of future transient spire startup failures.

## Why the Fix Is Stable

The webhook name improvement is purely additive and has no behavioral impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)