### PR TITLE
fix(e2e): include webhook name in spire retry description

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -2,6 +2,7 @@ package spire
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -84,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr


### PR DESCRIPTION
## Summary

Fixes #16

- Include `webhookName` in the `retry.DoWithRetryE` description in `waitForWebhookEndpoints` so CI logs clearly show which webhook is being waited for.

## Root Cause

The `test / test_e2e_env (sidecarContainers, v1.34.1-k3s1, kubernetes, amd64) / e2e (0)` job failed due to two related issues in the same CI run:

1. **Primary cause (already fixed)**: A mise symlink race condition in `mk/e2e.new.mk` where `test/e2e/k8s/start` ran kuma-1 and kuma-2 clusters as parallel make prerequisites. Both spawned subprocesses triggered `mise` auto-install simultaneously and raced to create the runtime symlink (`EEXIST: File exists`). Fixed in prior commits by running `MISE_DISABLE_TOOLS= $(MISE) install` serially before parallel cluster starts.

2. **Secondary cause (also already fixed)**: The `isPodReady` check for `app.kubernetes.io/name=spire-controller-manager` waited for a pod that never exists (spire-controller-manager runs as a sidecar inside the spire-server pod, not as a standalone Deployment). Fixed in prior commit by removing that check and relying on `waitForWebhookEndpoints` instead.

## What Was Changed

This PR makes a minor observability improvement: the `retry.DoWithRetryE` description in `waitForWebhookEndpoints` now includes the `webhookName` parameter, changing log output from:

```
wait for webhook endpoints (attempt 1/90)
```

to:

```
wait for spire-controller-manager-webhook webhook endpoints (attempt 1/90)
```

## Why the Fix Is Stable

This is a purely additive logging improvement — it changes only what appears in retry log output, not the retry logic itself. When debugging future `BeforeAll` failures in the MeshIdentity Spire test, the webhook name in the log makes it immediately clear which resource is not yet ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)