### PR TITLE
fix(test): increase SPIRE pod readiness timeout to prevent flaky BeforeAll

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -84,7 +84,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*6, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr
@@ -106,7 +106,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 			LabelSelector: selector,
 		},
 		1,
-		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 		framework.DefaultTimeout)
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 		if err := k8s.WaitUntilPodAvailableE(cluster.GetTesting(),
 			cluster.GetKubectlOptions(t.namespace),
 			pod.Name,
-			framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+			framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 			framework.DefaultTimeout); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Doubles the pod readiness retry multiplier from `DefaultRetries*3` to `DefaultRetries*6` in the SPIRE k8s deployment helper
- Applies to pod creation wait, pod availability wait, and webhook endpoint wait

## Root cause

The CI failure in PR #113 (and other SPIRE-related BeforeAll failures) is caused by the SPIRE agent pod taking longer than the 270-second timeout to become available on slow CI runners. CI logs show continuous retries from 12:04:06 through 12:09:24 — approximately 318 seconds — before the `k8s.WaitUntilPodAvailableE` call gave up.

SPIRE images are pulled from the internet (`https://spiffe.github.io/helm-charts-hardened/`), so image pull time varies greatly depending on network conditions and runner load.

## What changed

`test/framework/deployments/spire/kubernetes.go`: changed all three retry limits from `DefaultRetries*3` (90 retries × 3s = 270s max) to `DefaultRetries*6` (180 retries × 3s = 540s max):
- `WaitUntilNumPodsCreatedE` in `isPodReady`
- `WaitUntilPodAvailableE` in `isPodReady`
- `retry.DoWithRetryE` in `waitForWebhookEndpoints`

## Why the fix is stable

The observed worst-case image pull time was ~318s. A 540s limit gives ~70% headroom above the observed maximum while keeping the test from hanging forever (it will still fail after 9 minutes if something is genuinely broken). The change is purely additive — no test logic is altered, only the patience window is widened.

Fixes the flaky test surfaced by PR #113.