### PR TITLE
fix(ci): disable local-storage and wait for flannel before k3d readiness

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -59,6 +59,7 @@ K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--k3s-arg '--disable=metrics-server@server:0' \
 	--k3s-arg '--kubelet-arg=image-gc-high-threshold=100@server:0' \
 	--k3s-arg '--disable=servicelb@server:0' \
+	--k3s-arg '--disable=local-storage@server:0' \
     --volume '$(subst @,\@,$(TOP)/$(KUMA_DIR))/test/framework/deployments:/tmp/deployments@server:0' \
 	--network kind \
 	--port "$(PORT_PREFIX)80-$(PORT_PREFIX)99:30080-30099@server:0" \
@@ -183,10 +184,24 @@ k3d/configure/cni: k3d/configure/cni/$(K3D_NETWORK_CNI_EFFECTIVE)
 	  echo "[WARNING]: Unsupported K3D CNI '$(K3D_NETWORK_CNI_REQ)', falling back to '$(K3D_NETWORK_CNI_DEFAULT)'" >&2; \
 	fi
 
-# Default: flannel (no action required)
+# Default: flannel - wait for flannel to write subnet.env before proceeding.
+# Pod sandbox creation (via the flannel CNI plugin) fails with
+# "loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory"
+# if the flannel DaemonSet hasn't finished initializing its VXLAN interface yet.
+# Polling here ensures k3d/wait only starts after flannel is ready.
 .PHONY: k3d/configure/cni/flannel
 k3d/configure/cni/flannel:
-	@true
+	@echo "Waiting for flannel to initialize subnet.env..."; \
+	TRIES=0; MAX_TRIES=30; \
+	until docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 test -f /run/flannel/subnet.env 2>/dev/null; do \
+		TRIES=$$((TRIES+1)); \
+		if [[ $$TRIES -ge $$MAX_TRIES ]]; then \
+			echo "ERROR: flannel subnet.env not found after $$MAX_TRIES attempts"; exit 1; \
+		fi; \
+		echo "  flannel not ready yet (attempt $$TRIES/$$MAX_TRIES), retrying in 2s..."; \
+		sleep 2; \
+	done; \
+	echo "flannel subnet.env is ready"
 
 # Calico (runs when K3D_NETWORK_CNI=calico)
 .PHONY: k3d/configure/cni/calico


### PR DESCRIPTION
## Summary

Two targeted fixes for the cascading cluster startup failure in issue #127.

- Add `--disable=local-storage@server:0` to `K3D_CLUSTER_CREATE_OPTS` to eliminate the Docker Hub dependency during cluster startup
- Replace the no-op `k3d/configure/cni/flannel` target with an explicit poll for `/run/flannel/subnet.env`

Fixes #127

## Root Cause

The CI job `test / test_e2e (v1.34.1-k3s1, amd64, 4, flannel) / e2e (1)` failed during k3d cluster startup due to two cascading failures:

**1. Flannel initialization race** — flannel writes `/run/flannel/subnet.env` only after its VXLAN interface is fully initialized. The `k3d/configure/cni/flannel` target was a no-op (`@true`), so pod scheduling began immediately. Any pod that attempted sandbox creation before flannel was ready failed with:
```
plugin type="flannel" failed (add): loadFlannelSubnetEnv failed:
open /run/flannel/subnet.env: no such file or directory
```

**2. local-path-provisioner Docker Hub TLS timeout** — The `local-path-provisioner` pod pulled `rancher/local-path-provisioner:v0.0.32` from Docker Hub during cluster startup. A transient TLS handshake timeout caused `ImagePullBackOff`. Kubernetes exponential backoff grew retry intervals to several minutes, exhausting the `k3d/wait` budget.

## What Changed

**`mk/k3d.mk` — `K3D_CLUSTER_CREATE_OPTS`:**
- Added `--k3s-arg '--disable=local-storage@server:0'`
- Prevents k3s from deploying `local-path-provisioner` entirely, consistent with the existing pattern of disabling unused addons (`traefik`, `metrics-server`, `servicelb`)
- No e2e tests use PersistentVolumes or the `local-path` StorageClass

**`mk/k3d.mk` — `k3d/configure/cni/flannel` target:**
- Replaced `@true` (no-op) with a poll for `/run/flannel/subnet.env` on the k3d server node
- Polls every 2s for up to 60s (30 tries), fails with a clear message if flannel never initializes
- Since `k3d/configure/cni` runs before `k3d/wait` in `k3d/start`, this ensures the flannel network layer is ready before any pod readiness check begins

## Why This Should Be Stable

- **Disabling local-storage**: No `local-path-provisioner` pod → zero Docker Hub image pulls during setup → the transient TLS failure cannot recur
- **Flannel readiness poll**: Synchronizes explicitly on flannel's file-write event. Pod sandbox creation cannot fail with the `subnet.env` error because flannel is confirmed initialized before `k3d/wait` starts
- **Minimal and surgical**: only two targeted changes in `mk/k3d.mk`; no test code touched
- **Fails loudly**: real failures (flannel never starts, Docker Hub unreachable for other images) still surface with clear errors

## Test plan

- [ ] CI passes for `test / test_e2e (v1.34.1-k3s1, amd64, 4, flannel)` jobs
- [ ] No PersistentVolume-dependent tests break (confirmed none exist by grep)