### PR TITLE
fix(ci): disable local-storage and wait for flannel before k3d readiness

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -59,6 +59,7 @@ K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--k3s-arg '--disable=metrics-server@server:0' \
 	--k3s-arg '--kubelet-arg=image-gc-high-threshold=100@server:0' \
 	--k3s-arg '--disable=servicelb@server:0' \
+	--k3s-arg '--disable=local-storage@server:0' \
     --volume '$(subst @,\@,$(TOP)/$(KUMA_DIR))/test/framework/deployments:/tmp/deployments@server:0' \
 	--network kind \
 	--port "$(PORT_PREFIX)80-$(PORT_PREFIX)99:30080-30099@server:0" \
@@ -183,10 +184,19 @@ k3d/configure/cni: k3d/configure/cni/$(K3D_NETWORK_CNI_EFFECTIVE)
 	  echo "[WARNING]: Unsupported K3D CNI '$(K3D_NETWORK_CNI_REQ)', falling back to '$(K3D_NETWORK_CNI_DEFAULT)'" >&2; \
 	fi
 
-# Default: flannel (no action required)
+# Default: flannel — wait for flannel to write subnet.env before pod readiness checks begin
 .PHONY: k3d/configure/cni/flannel
 k3d/configure/cni/flannel:
-	@true
+	@echo "Waiting for flannel to initialize /run/flannel/subnet.env..."; \
+	TRIES=0; MAX_TRIES=30; \
+	until docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 test -f /run/flannel/subnet.env 2>/dev/null; do \
+		TRIES=$$((TRIES+1)); \
+		if [ $$TRIES -ge $$MAX_TRIES ]; then \
+			echo "Timed out waiting for flannel subnet.env"; exit 1; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "Flannel initialized."
 
 # Calico (runs when K3D_NETWORK_CNI=calico)
 .PHONY: k3d/configure/cni/calico


### PR DESCRIPTION
## Root Cause

Issue #127 (`test / test_e2e (v1.34.1-k3s1, amd64, 4, flannel) / e2e (1)`) failed during k3d cluster startup due to two cascading failures:

1. **Flannel initialization race**: `k3d/configure/cni/flannel` was a no-op (`@true`), so `k3d/wait` started polling pod readiness immediately after cluster creation — before flannel had written `/run/flannel/subnet.env`. Pods attempting sandbox creation failed with `loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory`, burning through the wait budget (~195s, just over the 3-minute window).

2. **local-path-provisioner Docker Hub TLS timeout**: k3s deploys `local-path-provisioner` by default, pulling `rancher/local-path-provisioner:v0.0.32` from Docker Hub. Under CI network pressure this hit TLS handshake timeouts and entered `ImagePullBackOff`, consuming the remaining wait budget and causing `k3d/wait` to exhaust its retries.

## What Changed

**`mk/k3d.mk`** — two targeted changes:

1. Added `--k3s-arg '--disable=local-storage@server:0'` to `K3D_CLUSTER_CREATE_OPTS` — prevents k3s from deploying `local-path-provisioner` entirely, eliminating the Docker Hub dependency. Follows the same pattern as the existing `traefik`, `metrics-server`, and `servicelb` disables. No e2e tests use PersistentVolumeClaims.

2. Replaced the no-op `k3d/configure/cni/flannel` target with an explicit poll for `/run/flannel/subnet.env` inside the k3d container (every 2s, up to 30 tries = 60s max). Since `k3d/configure/cni` runs before `k3d/wait` in `k3d/start`, pod readiness checks only begin after flannel is confirmed initialized.

## Why This Should Be Stable

- No `local-path-provisioner` pod → no Docker Hub image pulls during setup → TLS timeout failure cannot recur
- Explicit flannel synchronization on `/run/flannel/subnet.env` → pod sandbox creation cannot fail with the race condition
- Both fixes eliminate root causes rather than just extending timeouts

Note: A previous commit (a280979eb) already increased `MAX_ALLOWED_TRIES` to 60 as a stopgap. This PR addresses the underlying root causes directly.

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)