### PR TITLE
fix(e2e): use explicit duration in PERMISSIVE mTLS Consistently check

### DIFF
--- a/test/e2e_env/universal/mtls/mtls.go
+++ b/test/e2e_env/universal/mtls/mtls.go
@@ -153,7 +153,7 @@ mtls:
 			_, stderr, err := curlAddr("test-server.mesh")
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-		}).Should(Succeed())
+		}, "10s", "500ms").Should(Succeed())
 	})
 
 	DescribeTable("should enforce traffic permissions",


### PR DESCRIPTION
Fixes #128

## Root Cause

After enabling PERMISSIVE mTLS, `xDS` config propagation to Envoy sidecars can take several seconds on slow CI runners. The `Consistently` block was starting immediately after the mesh update, catching transient failures during the propagation window.

The initial fix (9dd6da653) added a `trafficAllowed("test-server.mesh")` call before `Consistently`, which waits for 10 consecutive successful requests confirming propagation is complete. This resolved the original race condition.

The remaining issue: `Consistently` used implicit default duration (5s / 200ms polling from `RunE2ESpecs`), making the stability window small and the intent unclear.

## What Changed

In `test/e2e_env/universal/mtls/mtls.go`: changed `Consistently(...)` to `Consistently(..., "10s", "500ms")` — explicit 10-second duration with 500ms polling interval.

## Why This Is Stable

- `trafficAllowed()` (10 × 250ms consecutive successes) acts as a synchronization barrier ensuring xDS propagation is complete before `Consistently` starts
- `Consistently` then verifies stability for **10 seconds** (vs implicit 5s default), providing a stronger stability guarantee
- Explicit parameters make the test intent clear and independent of global timeout configuration changes