### PR TITLE
fix(e2e): include webhook name in spire retry description

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -2,6 +2,7 @@ package spire
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -84,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), "wait for webhook endpoints", framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr


### PR DESCRIPTION
## Summary

Fixes #16

- Include `webhookName` in the `retry.DoWithRetryE` description in `waitForWebhookEndpoints` so CI logs clearly show which webhook is being waited for when debugging `BeforeAll` timeouts.

## Root Cause

The `test / test_e2e_env (sidecarContainers, v1.34.1-k3s1, kubernetes, amd64) / e2e (0)` job failed due to two causes in the CI run from 2026-03-18:

1. **Primary cause (already fixed in mk/e2e.new.mk)**: A mise symlink race condition where `test/e2e/k8s/start` ran kuma-1 and kuma-2 clusters as parallel make prerequisites. Both spawned subprocesses evaluated `$(shell $(MISE) which skaffold)` while parsing the Makefile. Since `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` was set during `jdx/mise-action` setup, both subprocesses raced to auto-install skaffold and failed with `EEXIST: File exists`. Fixed by running `MISE_DISABLE_TOOLS= $(MISE) install` serially before parallel cluster starts.

2. **Secondary cause (already fixed in spire/kubernetes.go)**: `isPodReady` with selector `app.kubernetes.io/name=spire-controller-manager` waited for a pod that never exists — spire-controller-manager runs as a sidecar inside the spire-server pod. Fixed by removing that check and relying on `waitForWebhookEndpoints` instead.

## What Was Changed

`test/framework/deployments/spire/kubernetes.go`: Updated the `retry.DoWithRetryE` description from `"wait for webhook endpoints"` to `fmt.Sprintf("wait for %s webhook endpoints", webhookName)`. When a `BeforeAll` timeout occurs in CI, logs now immediately show which webhook (e.g. `spire-controller-manager-webhook`) is not yet ready.

## Why the Fix Is Stable

This is a purely additive, informational change — it has no effect on retry logic, timeouts, or functional behavior. The webhook name in the retry description makes future `BeforeAll` timeout failures self-documenting in CI logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)