### PR TITLE
fix(ci): increase flannel subnet.env wait timeout to 240s

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -191,12 +191,12 @@ k3d/configure/cni: k3d/configure/cni/$(K3D_NETWORK_CNI_EFFECTIVE)
 .PHONY: k3d/configure/cni/flannel
 k3d/configure/cni/flannel:
 	@TIMES_TRIED=0; \
-	MAX_ALLOWED_TRIES=30; \
+	MAX_ALLOWED_TRIES=120; \
 	until docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 test -f /run/flannel/subnet.env 2>/dev/null; do \
 		echo "Waiting for flannel to initialize subnet.env..." && sleep 2; \
 		TIMES_TRIED=$$((TIMES_TRIED+1)); \
 		if [[ $$TIMES_TRIED -ge $$MAX_ALLOWED_TRIES ]]; then \
-			echo "Flannel subnet.env not created after 60s timeout"; \
+			echo "Flannel subnet.env not created after 240s timeout"; \
 			exit 1; \
 		fi; \
 	done; \


### PR DESCRIPTION
## Root Cause

The `k3d/configure/cni/flannel` target (added in d79754f1f) polls for `/run/flannel/subnet.env` on the k3d server node with `MAX_ALLOWED_TRIES=30` and a 2s sleep, giving a maximum wait of **60 seconds**. CI data from issue #127 showed flannel initialization took **3m15s (195s)** — more than 3× the 60s limit. Had the flannel wait been reached before the `k3d/wait` budget was exhausted, the cluster setup would have aborted immediately.

While the companion fix (disabling `local-storage` to remove the ImagePullBackOff pressure) alleviates some of the contention, flannel startup time is independent of local-path-provisioner and can still exceed 60s on a loaded CI runner.

## What Changed

Increased `MAX_ALLOWED_TRIES` from `30` to `120` in `mk/k3d.mk`'s `k3d/configure/cni/flannel` target, extending the maximum flannel wait from 60s to **240s (4 minutes)**. Updated the timeout message to match.

## Why This Should Be Stable

- The observed worst case was 195s; 240s provides a ~45s buffer above it
- Flannel initialization is self-healing — it always completes once the VXLAN interface is ready; no retry logic is needed beyond waiting
- This is a pure timeout extension: no logic changes, no risk of masking failures
- Genuine failures (flannel never starts) still surface after 4 minutes with a clear error message

Fixes: #127