### PR TITLE
fix(e2e): increase SPIRE pod and webhook readiness timeout

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -85,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*6, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr
@@ -107,7 +107,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 			LabelSelector: selector,
 		},
 		1,
-		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 		framework.DefaultTimeout)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 		if err := k8s.WaitUntilPodAvailableE(cluster.GetTesting(),
 			cluster.GetKubectlOptions(t.namespace),
 			pod.Name,
-			framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+			framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 			framework.DefaultTimeout); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes #16

Increases the retry multiplier from `DefaultRetries*3` (270s) to `DefaultRetries*6` (540s) for all three SPIRE readiness checks in `test/framework/deployments/spire/kubernetes.go`:
- `WaitUntilNumPodsCreatedE` in `isPodReady`
- `WaitUntilPodAvailableE` in `isPodReady`
- `retry.DoWithRetryE` in `waitForWebhookEndpoints`

## Root Cause

The `sidecarContainers` job (`test / test_e2e_env (sidecarContainers, v1.34.1-k3s1, kubernetes, amd64) / e2e (0)`) in CI run [23249787080](https://github.com/kumahq/kuma/actions/runs/23249787080) failed due to a mise symlink race condition. The primary fix — running `MISE_DISABLE_TOOLS= $(MISE) install` serially before parallel cluster starts in `mk/e2e.new.mk` — is already applied in prior commits.

A secondary source of flakiness remains: SPIRE pod readiness checks use `DefaultRetries*3` (90 retries × 3s = 270s max). SPIRE images are pulled from the internet (`https://spiffe.github.io/helm-charts-hardened/`), and on slow CI runners the pod availability wait has been observed to span ~318 seconds — exceeding the previous limit and causing `BeforeAll` to fail at `spire.go:58`.

The `sidecarContainers` suite runs all standard kubernetes E2E tests including `MeshIdentity Spire`, so this timeout flakiness affects the sidecarContainers job as well.

## What Was Changed

`test/framework/deployments/spire/kubernetes.go`: changed all three retry limits from `DefaultRetries*3` to `DefaultRetries*6` (180 retries × 3s = 540s max).

## Why the Fix Is Stable

`DefaultRetries*6` (540s) gives ~70% headroom above the observed 318s worst case, while still failing after 9 minutes if something is genuinely broken. The change is purely additive — no test logic is altered, only the patience window is widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)