### PR TITLE
fix(e2e): increase SPIRE readiness timeout from 270s to 540s

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -85,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*6, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr
@@ -107,7 +107,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 			LabelSelector: selector,
 		},
 		1,
-		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 		framework.DefaultTimeout)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 		if err := k8s.WaitUntilPodAvailableE(cluster.GetTesting(),
 			cluster.GetKubectlOptions(t.namespace),
 			pod.Name,
-			framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+			framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 			framework.DefaultTimeout); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes #16

Increases the retry multiplier from `DefaultRetries*3` (270s) to `DefaultRetries*6` (540s) for all three SPIRE readiness checks in `test/framework/deployments/spire/kubernetes.go`:
- `WaitUntilNumPodsCreatedE` in `isPodReady`
- `WaitUntilPodAvailableE` in `isPodReady`
- `retry.DoWithRetryE` in `waitForWebhookEndpoints`

## Root Cause

The `sidecarContainers` job (`test / test_e2e_env (sidecarContainers, v1.34.1-k3s1, kubernetes, amd64) / e2e (0)`) in CI run [23249787080](https://github.com/kumahq/kuma/actions/runs/23249787080) had two causes:

1. **Mise symlink race** (already fixed in prior commits): `test/e2e/k8s/start` ran `kuma-1` and `kuma-2` as parallel make prerequisites. Each spawned subprocess evaluated `$(shell $(MISE) which skaffold)` during Makefile parse. Since `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` was set during the `jdx/mise-action` setup step, both parallel subprocesses triggered mise auto-install simultaneously and raced to create the runtime symlink:
   ```
   mise ERROR failed to ln -sf ./2.18.0 /home/ubuntu/.local/share/mise/installs/skaffold/latest
   mise ERROR File exists (os error 17)
   make[2]: *** [mk/k3d.mk:157: k3d/start] Error 1
   ```
   Fixed in prior commits by running `MISE_DISABLE_TOOLS= $(MISE) install` serially before parallel cluster starts.

2. **SPIRE readiness timeout** (fixed here): SPIRE images are pulled from the internet on every CI run. On slow runners the previous `DefaultRetries*3` (270s) window was insufficient and caused `BeforeAll` timeouts. Observed worst-case pod startup time was ~318s, exceeding the 270s budget.

## What Was Changed

All three SPIRE readiness checks are increased from `DefaultRetries*3` to `DefaultRetries*6` (540s), providing ~70% headroom above the observed worst-case startup time.

## Why the Fix Is Stable

This is a purely additive change — only the patience window is widened. No test logic, retry policy, or assertion behavior is altered. `DefaultRetries*6` (540s) gives sufficient buffer for even the slowest observed SPIRE image pulls without impacting test run time when SPIRE starts normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)