### PR TITLE
fix(e2e): increase SPIRE readiness timeout from 270s to 540s

### DIFF
--- a/test/framework/deployments/spire/kubernetes.go
+++ b/test/framework/deployments/spire/kubernetes.go
@@ -85,7 +85,7 @@ func (t *k8sDeployment) waitForWebhookEndpoints(cluster framework.Cluster, webho
 		return errors.Wrapf(err, "error getting Kubernetes client")
 	}
 
-	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*3, framework.DefaultTimeout, func() (string, error) {
+	_, err = retry.DoWithRetryE(cluster.GetTesting(), fmt.Sprintf("wait for %s webhook endpoints", webhookName), framework.DefaultRetries*6, framework.DefaultTimeout, func() (string, error) {
 		endpoints, endpointErr := clientset.CoreV1().Endpoints(t.namespace).Get(context.Background(), webhookName, metav1.GetOptions{})
 		if endpointErr != nil {
 			return "", endpointErr
@@ -107,7 +107,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 			LabelSelector: selector,
 		},
 		1,
-		framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+		framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 		framework.DefaultTimeout)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func (t *k8sDeployment) isPodReady(cluster framework.Cluster, selector string) e
 		if err := k8s.WaitUntilPodAvailableE(cluster.GetTesting(),
 			cluster.GetKubectlOptions(t.namespace),
 			pod.Name,
-			framework.DefaultRetries*3, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
+			framework.DefaultRetries*6, // spire is fetched from the internet. Increase the timeout to prevent long downloads of images.
 			framework.DefaultTimeout); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Root Cause

The CI failure on PR #140 showed:
```
'Wait for num pods created to match desired count 1.' unsuccessful after 90 retries
```

The SPIRE `BeforeAll` in `test/e2e_env/kubernetes/meshidentity/spire.go` timed out waiting for SPIRE pods to appear. The current timeout of `DefaultRetries*3 = 90` × 3s = **270s** is insufficient on loaded CI runners where SPIRE images (`https://spiffe.github.io/helm-charts-hardened/`) must be pulled from the internet before pods can start.

## What Was Changed

Increased the retry multiplier from `DefaultRetries*3` to `DefaultRetries*6` (180 × 3s = **540s**) for all three readiness checks in `test/framework/deployments/spire/kubernetes.go`:
- `WaitUntilNumPodsCreatedE` in `isPodReady`
- `WaitUntilPodAvailableE` in `isPodReady`
- `retry.DoWithRetryE` in `waitForWebhookEndpoints`

## Why the Fix Is Stable

`DefaultRetries*6` (540s) provides 2× the previous budget, giving sufficient headroom for SPIRE images to pull and pods to start on slow CI runners. The change is purely additive — only the patience window is widened, no test logic is altered.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)