### PR TITLE
fix(kds): make shutdown-blocking sleeps interruptible

### DIFF
--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -63,7 +63,12 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 			backoff = r.newBackoff()
 		}
 		dur, _ := backoff.Next()
-		<-time.After(dur)
+		select {
+		case <-time.After(dur):
+		case <-stop:
+			r.log.Info("done")
+			return nil
+		}
 	}
 }
 

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -278,7 +278,11 @@ func (g *KDSSyncServiceServer) storeStreamConnection(ctx context.Context, zone s
 	// In this case, all instances will try to update Zone Insight which will result in conflicts.
 	// Since it's unusual to immediately execute envoy admin rpcs after zone is connected, 0-10s delay should be fine.
 	// #nosec G404 - math rand is enough
-	time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
+	select {
+	case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	zoneInsight := system.NewZoneInsightResource()
 	return core_manager.Upsert(ctx, g.resManager, key, zoneInsight, func(resource core_model.Resource) error {

--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -269,7 +269,11 @@ func (g *GlobalKDSServiceServer) storeStreamConnection(ctx context.Context, zone
 	// In this case, all instances will try to update Zone Insight which will result in conflicts.
 	// Since it's unusual to immediately execute envoy admin rpcs after zone is connected, 0-10s delay should be fine.
 	// #nosec G404 - math rand is enough
-	time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
+	select {
+	case <-time.After(time.Duration(rand.Int31n(10000)) * time.Millisecond):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	zoneInsight := system.NewZoneInsightResource()
 	return manager.Upsert(ctx, g.resManager, key, zoneInsight, func(resource model.Resource) error {


### PR DESCRIPTION
## Root Cause

Two sleep patterns in the KDS layer block goroutine cleanup during test shutdown, contributing to flakiness in `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled`:

1. **`resilient.go`**: `<-time.After(dur)` blocks unconditionally during the backoff sleep after a component error. If the `stop` channel is closed while a zone CP's mux-client is in backoff (after a transient connection error), the goroutine sleeps for up to `backoffMaxTime` before exiting.

2. **`zone_sync.go` and `service/server.go`**: `storeStreamConnection` contains an unconditional `time.Sleep(0–10s)` jitter before upserting ZoneInsight. When the test closes `done`, gRPC's `GracefulStop()` cancels active stream contexts and waits for all handlers to return. Any handler blocked mid-sleep holds up `wg.Wait()` for up to 10 seconds per zone.

Both issues extend the effective shutdown window. On slow CI runners, this widens the timing window for races that cause intermittent failures.

## What Changed

- **`pkg/core/runtime/component/resilient.go`**: Replaced `<-time.After(dur)` with a `select` that also watches `stop`, so the resilient component exits immediately when asked to stop, even mid-backoff.

- **`pkg/kds/mux/zone_sync.go`** and **`pkg/kds/service/server.go`**: Replaced the unconditional `time.Sleep` with a `select` that also watches `ctx.Done()`, returning `ctx.Err()` so stream handlers exit immediately when the gRPC stream context is cancelled on shutdown.

## Why the Fix Is Stable

- **Production behaviour is unchanged** on the normal (non-cancelled) path — the full 0–10s jitter and exponential backoff logic still apply.
- **Shutdown is now prompt**: after `close(done)`, all goroutines unblock immediately and `wg.Wait()` returns quickly, eliminating timing windows that could cause store checks to race with in-progress reconnections.
- **Minimal surface**: three surgical changes, no behavioural change except on shutdown/cancellation paths.

Closes #33