### PR TITLE
docs(e2e): document exact mise race condition trigger and affected tools

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -94,10 +94,13 @@ test/e2e/list:
 test/e2e/k8s/start:
 	# Pre-install all mise tools serially before parallel cluster starts.
 	# Without this, parallel make subprocesses race to auto-install tools
-	# excluded by MISE_DISABLE_TOOLS (e.g. golangci-lint) when they parse
-	# mk/dev.mk, causing EEXIST failures on the runtime symlink creation.
-	# MISE_DISABLE_TOOLS is cleared explicitly so that even if it is set in
-	# the environment (e.g. inherited from a CI step), all tools are installed.
+	# that are excluded by MISE_DISABLE_TOOLS in the CI workflow step
+	# (.github/workflows/_e2e.yaml: golangci-lint, skaffold). Any mise
+	# command parsed from mk/dev.mk (e.g. $(MISE) which go evaluated via
+	# :=) triggers mise auto-install for ALL missing tools, and both
+	# parallel processes race to rebuild runtime symlinks, failing with
+	# EEXIST. MISE_DISABLE_TOOLS is cleared explicitly here so that all
+	# tools are installed regardless of any inherited CI environment value.
 	MISE_DISABLE_TOOLS= $(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
@@ -115,10 +118,13 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 test/e2e/debug: $(E2E_DEPS_TARGETS)
 	# Pre-install all mise tools serially before parallel cluster starts.
 	# Without this, parallel make subprocesses race to auto-install tools
-	# excluded by MISE_DISABLE_TOOLS (e.g. golangci-lint) when they parse
-	# mk/dev.mk, causing EEXIST failures on the runtime symlink creation.
-	# MISE_DISABLE_TOOLS is cleared explicitly so that even if it is set in
-	# the environment (e.g. inherited from a CI step), all tools are installed.
+	# that are excluded by MISE_DISABLE_TOOLS in the CI workflow step
+	# (.github/workflows/_e2e.yaml: golangci-lint, skaffold). Any mise
+	# command parsed from mk/dev.mk (e.g. $(MISE) which go evaluated via
+	# :=) triggers mise auto-install for ALL missing tools, and both
+	# parallel processes race to rebuild runtime symlinks, failing with
+	# EEXIST. MISE_DISABLE_TOOLS is cleared explicitly here so that all
+	# tools are installed regardless of any inherited CI environment value.
 	MISE_DISABLE_TOOLS= $(MISE) install
 	$(MAKE) -j $(K8SCLUSTERS_START_TARGETS) build/kumactl images
 	$(MAKE) docker/tag


### PR DESCRIPTION
## Summary

Improves the comments in `test/e2e/k8s/start` and `test/e2e/debug` to more accurately describe the mise symlink race condition that caused the flake in issue #34.

- Names the specific excluded tools (`golangci-lint`, `skaffold`) with a cross-reference to `.github/workflows/_e2e.yaml` where they are excluded via `MISE_DISABLE_TOOLS`
- Explains that the race trigger is **any** mise command evaluated at Makefile parse time (e.g. `GO := $(shell $(MISE) which go)` — a `:=` assignment in `mk/dev.mk`), not just `$(MISE) which golangci-lint` specifically, because mise auto-installs **all** missing tools from `mise.toml` when triggered

## Root Cause (issue #34)

The `jdx/mise-action` step in `.github/workflows/_e2e.yaml` sets `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"`, leaving those tools uninstalled. When `test/e2e-multizone` ran `$(MAKE) -j $(K8SCLUSTERS_START_TARGETS)`, both `kuma-1` and `kuma-2` subprocesses parsed the full `Makefile` at startup. The first `:=` assignment in `mk/dev.mk` (`GO := $(shell $(MISE) which go)`) caused mise to auto-install all missing tools simultaneously. Both processes then raced to rebuild the `golangci-lint/latest` symlink, with the second failing:

```
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/latest
mise ERROR File exists (os error 17)
```

## What Changed

Updated comments to document the exact mechanism, including:
1. Which tools are excluded (`golangci-lint`, `skaffold`) and where (`_e2e.yaml`)
2. That **any** mise command at parse time is the trigger (not a specific `mise which golangci-lint` call)
3. Why `MISE_DISABLE_TOOLS=` is cleared explicitly before `$(MISE) install`

## Why the Fix Is Stable

The fix itself (`MISE_DISABLE_TOOLS= $(MISE) install` before parallel cluster starts) was already in place and is unchanged. These comment updates help future maintainers keep the fix in sync if the set of excluded tools in `.github/workflows/_e2e.yaml` ever changes.

## Test plan

- [ ] CI passes on `test/e2e-multizone` target with this change (no functional change, so all existing tests should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)