### PR TITLE
fix(ci): increase kind cluster wait timeout to match k3d

### DIFF
--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -56,7 +56,7 @@ kind/start: ${KUBECONFIG_DIR} kind/setup-docker-credentials
 .PHONY: kind/wait
 kind/wait:
 	@TIMES_TRIED=0; \
-	MAX_ALLOWED_TRIES=30; \
+	MAX_ALLOWED_TRIES=60; \
 	until KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; do \
 		echo "Waiting for the cluster to come up" && sleep 1; \
 		TIMES_TRIED=$$((TIMES_TRIED+1)); \


### PR DESCRIPTION
## Summary

Closes #127

- Increases `MAX_ALLOWED_TRIES` in `mk/kind.mk`'s `kind/wait` target from 30 to 60, matching the fix already applied to `mk/k3d.mk`

## Root Cause

The flaky CI failure on `test_e2e (v1.34.1-k3s1, amd64, 4, flannel)` was caused by `kube-system` pods (particularly flannel and `local-path-provisioner`) taking longer than the wait window to become Ready on slow/congested CI runners.

Three fixes were applied to `mk/k3d.mk`:
1. `MAX_ALLOWED_TRIES` increased from 30 → 60 (extending the window from ~180s to ~360s)
2. A dedicated flannel wait loop in `k3d/configure/cni/flannel` that polls for `/run/flannel/subnet.env` before pod scheduling begins
3. `--disable=local-storage` to prevent `local-path-provisioner` from being deployed (avoids Docker Hub pull flakiness)

`mk/kind.mk` was left with the old value of 30.

## What Changed

`mk/kind.mk`: `MAX_ALLOWED_TRIES` in `kind/wait` increased from 30 → 60, matching the value in `mk/k3d.mk`.

## Why This Is Stable

The change only increases the maximum wait window for `kube-system` pods to become ready. On fast clusters this has no effect (loop exits early on success). On slow or congested CI runners it gives up to ~360s instead of ~180s, matching the tolerance already proven sufficient in `mk/k3d.mk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)