### PR TITLE
fix(kds): make responseBackoff sleep interruptible in KDSSyncClient

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -174,6 +174,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 	}()
 
 	syncClient := kds_client_v2.NewKDSSyncClient(
+		stream.Context(),
 		log,
 		c.typesSentByGlobal,
 		deltaStream,

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -188,6 +188,7 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 	go func() {
 		kdsStream := kds_client_v2.NewDeltaKDSStream(stream, zone, g.instanceID, "", len(g.typesSentByZone))
 		sink := kds_client_v2.NewKDSSyncClient(
+			stream.Context(),
 			logger,
 			g.typesSentByZone,
 			kdsStream,

--- a/pkg/kds/v2/client/kds_client.go
+++ b/pkg/kds/v2/client/kds_client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	std_errors "errors"
 	"io"
 	"time"
@@ -53,6 +54,7 @@ type KDSSyncClient interface {
 }
 
 type kdsSyncClient struct {
+	ctx             context.Context
 	log             logr.Logger
 	resourceTypes   []core_model.ResourceType
 	callbacks       *Callbacks
@@ -61,6 +63,7 @@ type kdsSyncClient struct {
 }
 
 func NewKDSSyncClient(
+	ctx context.Context,
 	log logr.Logger,
 	rt []core_model.ResourceType,
 	kdsStream DeltaKDSStream,
@@ -68,6 +71,7 @@ func NewKDSSyncClient(
 	responseBackoff time.Duration,
 ) KDSSyncClient {
 	return &kdsSyncClient{
+		ctx:             ctx,
 		log:             log,
 		resourceTypes:   rt,
 		kdsStream:       kdsStream,
@@ -133,7 +137,11 @@ func (s *kdsSyncClient) Receive() error {
 		if !received.IsInitialRequest {
 			// Execute backoff only on subsequent request.
 			// When client first connects, the server sends empty DeltaDiscoveryResponse for every resource type.
-			time.Sleep(s.responseBackoff)
+			select {
+			case <-s.ctx.Done():
+				return s.ctx.Err()
+			case <-time.After(s.responseBackoff):
+			}
 		}
 		s.log.V(1).Info("sending ACK", "type", received.Type)
 		if err := s.kdsStream.ACK(received.Type); err != nil {

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -96,6 +96,7 @@ var _ = Describe("Zone Delta Sync", func() {
 		go func() {
 			defer wg.Done()
 			policySync := client_v2.NewKDSSyncClient(
+				context.Background(),
 				core.Log.WithName("kds-sink"),
 				kdsCtx.TypesSentByGlobal,
 				client_v2.NewDeltaKDSStream(clientStream, zoneName, "zone-inst", "", len(kdsCtx.TypesSentByGlobal)),

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -13,7 +13,7 @@ func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, resourceTypes
 	for i := 0; i < len(clientStreams); i++ {
 		clientID := fmt.Sprintf("client-%d", i)
 		item := clientStreams[i]
-		comp := kds_client_v2.NewKDSSyncClient(core.Log.WithName("kds").WithName(clientID), resourceTypes, kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes)), cb, 0)
+		comp := kds_client_v2.NewKDSSyncClient(item.Context(), core.Log.WithName("kds").WithName(clientID), resourceTypes, kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes)), cb, 0)
 		go func() {
 			_ = comp.Receive()
 			_ = item.CloseSend()


### PR DESCRIPTION
## Summary

- The `responseBackoff` sleep in `KDSSyncClient.Receive()` used `time.Sleep`, which blocks unconditionally even when the gRPC stream is cancelled during shutdown.
- Zone KDS `responseBackoff` defaults to 2 s, so each active zone stream handler could delay teardown by up to 2 s per response cycle — widening the race window in `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled`.
- Pass the stream context to `NewKDSSyncClient` at all call sites and replace `time.Sleep(s.responseBackoff)` with `select { case <-s.ctx.Done(): return s.ctx.Err(); case <-time.After(s.responseBackoff): }`.

Closes #33

## Root cause

`KDSSyncClient.Receive()` calls `time.Sleep(responseBackoff)` between processing a delta response and sending ACK. When the gRPC stream context is cancelled (because the component's `stop` channel was closed), the goroutine running `Receive()` would block for the full `responseBackoff` duration before it could detect the cancellation on the next `kdsStream.Receive()` call. This is the same class of blocking-sleep bug fixed in `resilient.go`, `zone_sync.go/storeStreamConnection`, and `server.go/storeStreamConnection` in the previous commit.

## What changed

- **`pkg/kds/v2/client/kds_client.go`**: Added `ctx context.Context` field to `kdsSyncClient`; added `ctx` as first parameter to `NewKDSSyncClient`; replaced `time.Sleep(s.responseBackoff)` with a `select` that exits immediately on `ctx.Done()`.
- **`pkg/kds/mux/client.go`**: Pass `stream.Context()` as the first argument to `NewKDSSyncClient`.
- **`pkg/kds/mux/zone_sync.go`**: Pass `stream.Context()` as the first argument to `NewKDSSyncClient`.
- **`pkg/test/kds/setup/client.go`**: Pass `item.Context()` as the first argument to `NewKDSSyncClient`.

## Why the fix is stable

Normal (non-cancelled) operation is unchanged — the backoff still applies. On shutdown, the stream context is cancelled, so the sleep exits immediately and `Receive()` returns `ctx.Err()` (which callers already treat as a graceful cancellation). This eliminates up to 2 s of stall per active zone stream during teardown.

## Test plan

- [ ] Existing unit tests in `pkg/kds/...` pass
- [ ] `Full sync tests [It] testdata/full_sync/policy-with-kds-disabled` passes consistently with `ci/verify-stability`

🤖 Generated with [Claude Code](https://claude.com/claude-code)